### PR TITLE
Enhance installation experience with improved PATH handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ make install ASSUME_DEFAULT=true     # Use default namespace (no detection)
 make install VELERO_NAMESPACE=custom # Use specific namespace (no detection)
 ```
 
-**💡 Important:** After installation, you may need to refresh your terminal or run `source ~/.zshrc` (or `~/.bashrc`) for the `kubectl oadp` command to work.
+**💡 Path Setup:** The installer will automatically check your PATH and guide you through any necessary setup. If `kubectl oadp` doesn't work immediately after installation, follow the on-screen instructions to update your PATH for the current session or restart your terminal.
 
 You can set the velero namespace afterwards using the oadp client command
 


### PR DESCRIPTION
## Overview
This PR improves the user experience during installation by providing clearer guidance and better PATH management to help users get `kubectl oadp` working immediately after installation.

## Background
Currently, users may experience confusion after running `make install` when `kubectl oadp` doesn't work immediately. This typically happens when `~/.local/bin` isn't in their current terminal session's PATH, even if it's configured in their shell profile.

## Improvements

### 1. Enhanced PATH Detection & Feedback
- Added clear status messages to show whether the install directory is in the current PATH
- Provides immediate feedback about PATH configuration status

### 2. Current Session Support  
- Now provides the exact `export PATH=...` command for immediate use
- Users can start using `kubectl oadp` right away without restarting their terminal

### 3. Improved Shell Configuration Detection
- Enhanced pattern matching to only detect active (non-commented) PATH exports
- Uses regex `^[[:space:]]*export[[:space:]]*PATH.*\.local/bin` for more accurate detection

### 4. Installation Verification
- Automatically verifies that `kubectl oadp` is accessible after installation
- Uses scoped PATH modification for testing without affecting the user's session
- Displays version information when cluster access is available

### 5. Clearer User Guidance
- Organized instructions into logical sections:
  - 🔧 Immediate solution for current session
  - 🔄 Setup for future sessions  
  - 🧪 Verification results
  - 📋 Helpful next steps

### 6. Updated Documentation
- Refined README.md to better explain the installation process
- Improved language around PATH setup requirements

## Example Output
The new installation experience provides clear, actionable guidance:

```
✅ Installed to ~/.local/bin
🔍 Checking PATH configuration...
⚠️  ~/.local/bin is not in your current PATH

🔧 To use kubectl oadp in this terminal session:
   export PATH="~/.local/bin:$PATH"

🔄 For future sessions:
   Restart your terminal or run: source ~/.zshrc

🧪 Verifying installation...
✅ Installation verified: kubectl oadp plugin is accessible
```

This change helps ensure users can successfully use the CLI immediately after installation while providing clear guidance for both immediate and future use.

🤖 Generated with [Claude Code](https://claude.ai/code)