### PR TITLE
fix oadp detection commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,31 +162,31 @@ install: build ## Build and install the kubectl plugin to ~/.local/bin (no sudo 
 	if [[ "$(ASSUME_DEFAULT)" != "true" && "$(VELERO_NAMESPACE)" == "openshift-adp" ]]; then \
 		echo ""; \
 		echo "🔍 Detecting OADP deployment in cluster..."; \
-		DETECTED_NS=$$(kubectl get deployment openshift-adp-controller-manager --all-namespaces -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null | head -1); \
+		DETECTED_NS=$$(kubectl get deployments --all-namespaces -o jsonpath='{.items[?(@.metadata.name=="openshift-adp-controller-manager")].metadata.namespace}' 2>/dev/null | head -1); \
 		if [[ -n "$$DETECTED_NS" ]]; then \
 			echo "✅ Found OADP controller in namespace: $$DETECTED_NS"; \
 			NAMESPACE=$$DETECTED_NS; \
 			DETECTED=true; \
 		else \
 			echo "   Could not find openshift-adp-controller-manager deployment"; \
-			echo "🔍 Looking for DataProtectionApplication (DPA) resources..."; \
-			DETECTED_NS=$$(kubectl get dataprotectionapplication --all-namespaces -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null | head -1); \
-			if [[ -n "$$DETECTED_NS" ]]; then \
-				echo "✅ Found DPA resource in namespace: $$DETECTED_NS"; \
-				NAMESPACE=$$DETECTED_NS; \
-				DETECTED=true; \
-			else \
-				echo "   Could not find DataProtectionApplication resources"; \
-				echo "🔍 Looking for Velero deployment as fallback..."; \
-				DETECTED_NS=$$(kubectl get deployment velero --all-namespaces -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null | head -1); \
-				if [[ -n "$$DETECTED_NS" ]]; then \
-					echo "✅ Found Velero deployment in namespace: $$DETECTED_NS"; \
-					NAMESPACE=$$DETECTED_NS; \
-					DETECTED=true; \
-				else \
-					echo "⚠️  Could not detect OADP or Velero deployment in cluster"; \
-				fi; \
-			fi; \
+		fi; \
+		echo "🔍 Looking for DataProtectionApplication (DPA) resources..."; \
+		DETECTED_NS=$$(kubectl get dataprotectionapplication --all-namespaces -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null | head -1); \
+		if [[ -n "$$DETECTED_NS" ]]; then \
+			echo "✅ Found DPA resource in namespace: $$DETECTED_NS"; \
+			NAMESPACE=$$DETECTED_NS; \
+			DETECTED=true; \
+		else \
+			echo "   Could not find DataProtectionApplication resources"; \
+		fi; \
+		echo "🔍 Looking for Velero deployment as fallback..."; \
+		DETECTED_NS=$$(kubectl get deployments --all-namespaces -o jsonpath='{.items[?(@.metadata.name=="velero")].metadata.namespace}' 2>/dev/null | head -1); \
+		if [[ -n "$$DETECTED_NS" ]]; then \
+			echo "✅ Found Velero deployment in namespace: $$DETECTED_NS"; \
+			NAMESPACE=$$DETECTED_NS; \
+			DETECTED=true; \
+		else \
+			echo "⚠️  Could not detect OADP or Velero deployment in cluster"; \
 		fi; \
 		if [[ "$$DETECTED" == "false" ]]; then \
 			echo "🤔 Which namespace should admin commands use for Velero resources?"; \


### PR DESCRIPTION
## Why the changes were made

The OADP CLI installation process was failing to detect existing OADP deployments in the cluster, even when they were properly installed. This was caused by incorrect kubectl commands in the detection logic that tried to retrieve specific named resources across all namespaces, which is not supported by kubectl.

Problems fixed:

CLI incorrectly reported "Could not find openshift-adp-controller-manager deployment" even when the deployment existed

CLI incorrectly reported "Could not find Velero deployment" even when Velero deployments existed

Users with properly installed OADP were unable to use the CLI due to false negative detection

Root cause: The commands kubectl get deployment <name> --all-namespaces don't work because kubectl doesn't allow retrieving specific named resources across all namespaces. This caused the detection logic to always fail, even when deployments existed.

Also, This PR includes changes to make sure 

1. OADP deployment
2. DPA check
3. Velero deployment

All the 3 checks are performed everytime.

Output before fix( even when oadp controller was installed with no DPA) :

`
📋 Configuration:

🔍 Detecting OADP deployment in cluster...
   Could not find openshift-adp-controller-manager deployment
🔍 Looking for DataProtectionApplication (DPA) resources...
   Could not find DataProtectionApplication resources
🔍 Looking for Velero deployment as fallback...
⚠️  Could not detect OADP or Velero deployment in cluster
🤔 Which namespace should admin commands use for Velero resources?
   (Common options: openshift-adp, velero, oadp)
`


## How to test the changes made

make install


Output after fix (when oadp is installed with DPA)

`make install
Building kubectl-oadp for current platform (darwin/arm64)...
✅ Built kubectl-oadp successfully!
Installing kubectl-oadp to /Users/ssingla/.local/bin...
✅ Installed to /Users/ssingla/.local/bin

🔍 Checking PATH configuration...
✅ /Users/ssingla/.local/bin is already in PATH


📋 Configuration:

🔍 Detecting OADP deployment in cluster...
✅ Found OADP controller in namespace: openshift-adp
🔍 Looking for DataProtectionApplication (DPA) resources...
✅ Found DPA resource in namespace: openshift-adp
🔍 Looking for Velero deployment as fallback...
✅ Found Velero deployment in namespace: openshift-adp

Setting Velero namespace to: openshift-adp
✅ Client config initialized

🧪 Verifying installation...
✅ Installation verified: kubectl oadp plugin is accessible
Client:
	Version: 
	Git commit: -
Server:
	Version: v1.16.1-OADP

📋 Next steps:
  1. Test admin commands: kubectl oadp backup get
  2. Test non-admin commands: kubectl oadp nonadmin backup get
  3. Manage NABSL requests: kubectl oadp nabsl get
  4. Change namespace: kubectl oadp client config set namespace=<namespace>`