### PR TITLE
quay.io binary push on release 

### DIFF
--- a/.github/workflows/quay_binaries_push.yml
+++ b/.github/workflows/quay_binaries_push.yml
@@ -1,0 +1,30 @@
+# Push binaries to Quay.io, when a new release is created
+name: oadp-cli binaries image push
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+# Check out code, podman login, run podman build, push to 
+jobs:
+  push-binaries:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Podman login
+        run: podman login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+
+      - name: Podman build and tag
+        run: |
+          podman build -f Dockerfile.download \
+            -t quay.io/konveyor/oadp-cli-binaries:${{ github.ref_name }} \
+            -t quay.io/konveyor/oadp-cli-binaries:latest .
+      
+      - name: Podman push version tag
+        run: podman push quay.io/konveyor/oadp-cli-binaries:${{ github.ref_name }}
+      
+      - name: Podman push latest tag
+        run: podman push quay.io/konveyor/oadp-cli-binaries:latest

--- a/Dockerfile.download
+++ b/Dockerfile.download
@@ -23,7 +23,7 @@ RUN make release-build && \
     rm -rf /root/.cache/go-build && \
     rm -rf /go/pkg
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Only copy compressed tarballs (much smaller than raw binaries)
 COPY --from=builder /archives /archives


### PR DESCRIPTION
## Why the changes were made

- Add new quay_binary_push workflow to push oadp-cli-binaries image to [quay.io/konveyor/oadp-cli-binaries](https://quay.io/repository/konveyor/oadp-cli-binaries?namespace=konveyor)
- Change runner image to ubi9 for dockefile

## How to test the changes made

podman build and podman run to see the server up

closes #74 