### PR TITLE
fixed help section to be using oc oadp uniformly

### DIFF
--- a/cmd/nabsl-request/approve.go
+++ b/cmd/nabsl-request/approve.go
@@ -40,10 +40,10 @@ func NewApproveCommand(f client.Factory) *cobra.Command {
 		Long:  "Approve a pending backup storage location request to allow the controller to create the corresponding BackupStorageLocation",
 		Args:  cobra.ExactArgs(1),
 		Example: `  # Approve a request by NABSL name (admin access required)
-  kubectl oadp nabsl-request approve user-test-bsl
+  oc oadp nabsl-request approve user-test-bsl
 
   # Approve a request by UUID with reason
-  kubectl oadp nabsl-request approve nacuser01-user-test-bsl-96dfa8b7-3f6f-4c8d-a168-8527b00fbed8 --reason "Approved for production use"`,
+  oc oadp nabsl-request approve nacuser01-user-test-bsl-96dfa8b7-3f6f-4c8d-a168-8527b00fbed8 --reason "Approved for production use"`,
 		Run: func(c *cobra.Command, args []string) {
 			cmd.CheckError(o.Complete(args, f))
 			cmd.CheckError(o.Validate(c, args, f))

--- a/cmd/nabsl-request/describe.go
+++ b/cmd/nabsl-request/describe.go
@@ -44,10 +44,10 @@ func NewDescribeCommand(f client.Factory) *cobra.Command {
 			cmd.CheckError(o.Run(c, f))
 		},
 		Example: `  # Describe a request by NABSL name
-  kubectl oadp nabsl-request describe my-bsl-request
+  oc oadp nabsl-request describe my-bsl-request
 
   # Describe a request by UUID
-  kubectl oadp nabsl-request describe nacuser01-my-bsl-96dfa8b7-3f6f-4c8d-a168-8527b00fbed8`,
+  oc oadp nabsl-request describe nacuser01-my-bsl-96dfa8b7-3f6f-4c8d-a168-8527b00fbed8`,
 	}
 
 	return c

--- a/cmd/nabsl-request/get.go
+++ b/cmd/nabsl-request/get.go
@@ -47,16 +47,16 @@ func NewGetCommand(f client.Factory) *cobra.Command {
 			cmd.CheckError(o.Run(c, f))
 		},
 		Example: `  # Get all backup storage location requests (admin access required)
-  kubectl oadp nabsl-request get
+  oc oadp nabsl-request get
 
   # Get a specific request by NABSL name
-  kubectl oadp nabsl-request get my-bsl-request
+  oc oadp nabsl-request get my-bsl-request
 
   # Get a specific request by UUID
-  kubectl oadp nabsl-request get nacuser01-my-bsl-96dfa8b7-3f6f-4c8d-a168-8527b00fbed8
+  oc oadp nabsl-request get nacuser01-my-bsl-96dfa8b7-3f6f-4c8d-a168-8527b00fbed8
 
   # Get output in YAML format
-  kubectl oadp nabsl-request get my-bsl-request -o yaml`,
+  oc oadp nabsl-request get my-bsl-request -o yaml`,
 	}
 
 	o.BindFlags(c.Flags())

--- a/cmd/nabsl-request/nabsl.go
+++ b/cmd/nabsl-request/nabsl.go
@@ -33,16 +33,16 @@ When users create NABSLs, approval requests are automatically generated for admi
 
 Use these commands to view, approve, or reject pending NABSL requests.`,
 		Example: `  # List all pending NABSL approval requests
-  kubectl oadp nabsl-request get
+  oc oadp nabsl-request get
 
   # Describe a specific NABSL approval request
-  kubectl oadp nabsl-request describe my-storage-request
+  oc oadp nabsl-request describe my-storage-request
 
   # Approve a NABSL approval request
-  kubectl oadp nabsl-request approve my-storage-request
+  oc oadp nabsl-request approve my-storage-request
 
   # Reject a NABSL approval request  
-  kubectl oadp nabsl-request reject my-storage-request`,
+  oc oadp nabsl-request reject my-storage-request`,
 	}
 
 	c.AddCommand(

--- a/cmd/nabsl-request/reject.go
+++ b/cmd/nabsl-request/reject.go
@@ -40,10 +40,10 @@ func NewRejectCommand(f client.Factory) *cobra.Command {
 		Long:  "Reject a pending backup storage location request to deny the user's request for a backup storage location",
 		Args:  cobra.ExactArgs(1),
 		Example: `  # Deny a request by NABSL name (admin access required)
-  kubectl oadp nabsl-request reject user-test-bsl --reason "Invalid configuration"
+  oc oadp nabsl-request reject user-test-bsl --reason "Invalid configuration"
 
   # Deny a request by UUID with detailed reason
-  kubectl oadp nabsl-request reject nacuser01-user-test-bsl-96dfa8b7-3f6f-4c8d-a168-8527b00fbed8 --reason "Bucket does not exist in specified region"`,
+  oc oadp nabsl-request reject nacuser01-user-test-bsl-96dfa8b7-3f6f-4c8d-a168-8527b00fbed8 --reason "Bucket does not exist in specified region"`,
 		Run: func(c *cobra.Command, args []string) {
 			cmd.CheckError(o.Complete(args, f))
 			cmd.CheckError(o.Validate(c, args, f))

--- a/cmd/non-admin/backup/backup_test.go
+++ b/cmd/non-admin/backup/backup_test.go
@@ -259,7 +259,7 @@ func TestNonAdminBackupExamples(t *testing.T) {
 
 	t.Run("create examples use correct command format", func(t *testing.T) {
 		expectedExamples := []string{
-			"kubectl oadp nonadmin backup create",
+			"oc oadp nonadmin backup create",
 			"--storage-location",
 			"--include-resources",
 			"--exclude-resources",
@@ -365,13 +365,13 @@ func TestVerbNounOrderExamples(t *testing.T) {
 	binaryPath := testutil.BuildCLIBinary(t)
 
 	t.Run("verb commands show proper examples", func(t *testing.T) {
-		// Test that verb commands show examples with kubectl oadp prefix
+		// Test that verb commands show examples with oc oadp prefix
 		expectedExamples := []string{
-			"kubectl oadp nonadmin get backup",
-			"kubectl oadp nonadmin create backup",
-			"kubectl oadp nonadmin delete backup",
-			"kubectl oadp nonadmin describe backup",
-			"kubectl oadp nonadmin logs backup",
+			"oc oadp nonadmin get backup",
+			"oc oadp nonadmin create backup",
+			"oc oadp nonadmin delete backup",
+			"oc oadp nonadmin describe backup",
+			"oc oadp nonadmin logs backup",
 		}
 
 		commands := [][]string{
@@ -390,11 +390,11 @@ func TestVerbNounOrderExamples(t *testing.T) {
 	t.Run("verb commands with specific resources show proper examples", func(t *testing.T) {
 		// Test that verb commands with specific resources show examples (noun-first format from underlying commands)
 		expectedExamples := []string{
-			"kubectl oadp nonadmin backup get",
-			"kubectl oadp nonadmin backup create backup1",
-			"kubectl oadp nonadmin backup delete my-backup",
-			"kubectl oadp nonadmin backup describe my-backup",
-			"kubectl oadp nonadmin backup logs my-backup",
+			"oc oadp nonadmin backup get",
+			"oc oadp nonadmin backup create backup1",
+			"oc oadp nonadmin backup delete my-backup",
+			"oc oadp nonadmin backup describe my-backup",
+			"oc oadp nonadmin backup logs my-backup",
 		}
 
 		commands := [][]string{
@@ -413,11 +413,11 @@ func TestVerbNounOrderExamples(t *testing.T) {
 	t.Run("shorthand verb commands show proper examples", func(t *testing.T) {
 		// Test that shorthand verb commands show examples
 		expectedExamples := []string{
-			"kubectl oadp nonadmin get backup",
-			"kubectl oadp nonadmin create backup",
-			"kubectl oadp nonadmin delete backup",
-			"kubectl oadp nonadmin describe backup",
-			"kubectl oadp nonadmin logs backup",
+			"oc oadp nonadmin get backup",
+			"oc oadp nonadmin create backup",
+			"oc oadp nonadmin delete backup",
+			"oc oadp nonadmin describe backup",
+			"oc oadp nonadmin logs backup",
 		}
 
 		commands := [][]string{
@@ -502,9 +502,9 @@ func TestNonAdminBackupDeleteAllFlagExamples(t *testing.T) {
 	t.Run("delete help has examples section", func(t *testing.T) {
 		// Test that examples section exists and shows various delete patterns
 		expectedExamples := []string{
-			"kubectl oadp nonadmin backup delete my-backup",
-			"kubectl oadp nonadmin backup delete --all",
-			"kubectl oadp nonadmin backup delete my-backup --confirm",
+			"oc oadp nonadmin backup delete my-backup",
+			"oc oadp nonadmin backup delete --all",
+			"oc oadp nonadmin backup delete my-backup --confirm",
 		}
 
 		testutil.TestHelpCommand(t, binaryPath,

--- a/cmd/non-admin/backup/create.go
+++ b/cmd/non-admin/backup/create.go
@@ -50,22 +50,22 @@ func NewCreateCommand(f client.Factory, use string) *cobra.Command {
 			cmd.CheckError(o.Run(c, f))
 		},
 		Example: `  # Create a simple backup of all resources in the current namespace.
-  kubectl oadp nonadmin backup create backup1
+  oc oadp nonadmin backup create backup1
 
   # Create a backup with specific resource types.
-  kubectl oadp nonadmin backup create backup2 --include-resources deployments,services
+  oc oadp nonadmin backup create backup2 --include-resources deployments,services
 
   # Create a backup with label selector.
-  kubectl oadp nonadmin backup create backup3 --selector app=myapp
+  oc oadp nonadmin backup create backup3 --selector app=myapp
 
   # Create a backup with snapshots and TTL.
-  kubectl oadp nonadmin backup create backup4 --snapshot-volumes --ttl 720h
+  oc oadp nonadmin backup create backup4 --snapshot-volumes --ttl 720h
 
   # Create a backup with specific storage location.
-  kubectl oadp nonadmin backup create backup5 --storage-location my-nabsl
+  oc oadp nonadmin backup create backup5 --storage-location my-nabsl
 
   # View the YAML for a backup without sending it to the server.
-  kubectl oadp nonadmin backup create backup6 -o yaml`,
+  oc oadp nonadmin backup create backup6 -o yaml`,
 	}
 
 	o.BindFlags(c.Flags())

--- a/cmd/non-admin/backup/delete.go
+++ b/cmd/non-admin/backup/delete.go
@@ -58,16 +58,16 @@ func NewDeleteCommand(f client.Factory, use string) *cobra.Command {
 			cmd.CheckError(o.Run())
 		},
 		Example: `  # Delete a specific backup
-  kubectl oadp nonadmin backup delete my-backup
+  oc oadp nonadmin backup delete my-backup
 
   # Delete multiple backups
-  kubectl oadp nonadmin backup delete backup1 backup2 backup3
+  oc oadp nonadmin backup delete backup1 backup2 backup3
 
   # Delete all backups in the current namespace
-  kubectl oadp nonadmin backup delete --all
+  oc oadp nonadmin backup delete --all
 
   # Delete without confirmation prompt
-  kubectl oadp nonadmin backup delete my-backup --confirm`,
+  oc oadp nonadmin backup delete my-backup --confirm`,
 	}
 
 	o.BindFlags(c.Flags())
@@ -204,7 +204,7 @@ func (o *DeleteOptions) Run() error {
 		fmt.Println()
 		fmt.Println("ℹ️  Note: The actual backup deletion will be performed asynchronously by the OADP controller.")
 		fmt.Println("   This may take some time to complete. You can monitor progress with:")
-		fmt.Printf("   kubectl get nonadminbackup -n %s\n", o.Namespace)
+		fmt.Printf("   oc get nonadminbackup -n %s\n", o.Namespace)
 	}
 
 	if len(failed) > 0 {

--- a/cmd/non-admin/backup/describe.go
+++ b/cmd/non-admin/backup/describe.go
@@ -83,9 +83,9 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 
 			return nil
 		},
-		Example: `  kubectl oadp nonadmin backup describe my-backup
-  kubectl oadp nonadmin backup describe my-backup --details
-  kubectl oadp nonadmin backup describe my-backup --details --request-timeout=30m`,
+		Example: `  oc oadp nonadmin backup describe my-backup
+  oc oadp nonadmin backup describe my-backup --details
+  oc oadp nonadmin backup describe my-backup --details --request-timeout=30m`,
 	}
 
 	c.Flags().DurationVar(&requestTimeout, "request-timeout", 0, fmt.Sprintf("The length of time to wait before giving up on a single server request (e.g., 30s, 5m, 1h). Overrides %s env var. Default: %v", shared.TimeoutEnvVar, shared.DefaultHTTPTimeout))

--- a/cmd/non-admin/backup/get.go
+++ b/cmd/non-admin/backup/get.go
@@ -87,16 +87,16 @@ func NewGetCommand(f client.Factory, use string) *cobra.Command {
 			}
 		},
 		Example: `  # Get all non-admin backups in the current namespace
-  kubectl oadp nonadmin backup get
+  oc oadp nonadmin backup get
 
   # Get a specific non-admin backup
-  kubectl oadp nonadmin backup get my-backup
+  oc oadp nonadmin backup get my-backup
 
   # Get backups in YAML format
-  kubectl oadp nonadmin backup get -o yaml
+  oc oadp nonadmin backup get -o yaml
 
   # Get a specific backup in JSON format
-  kubectl oadp nonadmin backup get my-backup -o json`,
+  oc oadp nonadmin backup get my-backup -o json`,
 	}
 
 	output.BindFlags(c.Flags())

--- a/cmd/non-admin/backup/logs.go
+++ b/cmd/non-admin/backup/logs.go
@@ -135,8 +135,8 @@ func NewLogsCommand(f client.Factory, use string) *cobra.Command {
 
 			return nil
 		},
-		Example: `  kubectl oadp nonadmin backup logs my-backup
-  kubectl oadp nonadmin backup logs my-backup --request-timeout=30m`,
+		Example: `  oc oadp nonadmin backup logs my-backup
+  oc oadp nonadmin backup logs my-backup --request-timeout=30m`,
 	}
 
 	c.Flags().DurationVar(&requestTimeout, "request-timeout", 0, fmt.Sprintf("The length of time to wait before giving up on a single server request (e.g., 30s, 5m, 1h). Overrides %s env var. Default: %v", shared.TimeoutEnvVar, shared.DefaultHTTPTimeout))

--- a/cmd/non-admin/bsl/bsl_test.go
+++ b/cmd/non-admin/bsl/bsl_test.go
@@ -165,7 +165,7 @@ func TestNonAdminBSLExamples(t *testing.T) {
 
 	t.Run("create examples use correct command format", func(t *testing.T) {
 		expectedExamples := []string{
-			"kubectl oadp nonadmin bsl create",
+			"oc oadp nonadmin bsl create",
 			"--provider",
 			"--bucket",
 			"--credential",
@@ -178,7 +178,7 @@ func TestNonAdminBSLExamples(t *testing.T) {
 
 	t.Run("get examples use correct command format", func(t *testing.T) {
 		expectedExamples := []string{
-			"kubectl oadp nonadmin bsl get",
+			"oc oadp nonadmin bsl get",
 		}
 
 		testutil.TestHelpCommand(t, binaryPath,
@@ -273,7 +273,7 @@ func TestVerbNounOrderBSLExamples(t *testing.T) {
 
 	t.Run("get verb command shows bsl examples", func(t *testing.T) {
 		expectedExamples := []string{
-			"kubectl oadp nonadmin get bsl",
+			"oc oadp nonadmin get bsl",
 		}
 
 		testutil.TestHelpCommand(t, binaryPath,
@@ -283,7 +283,7 @@ func TestVerbNounOrderBSLExamples(t *testing.T) {
 
 	t.Run("create verb command shows bsl examples", func(t *testing.T) {
 		expectedExamples := []string{
-			"kubectl oadp nonadmin create bsl",
+			"oc oadp nonadmin create bsl",
 		}
 
 		testutil.TestHelpCommand(t, binaryPath,
@@ -293,7 +293,7 @@ func TestVerbNounOrderBSLExamples(t *testing.T) {
 
 	t.Run("get bsl with specific resource shows proper examples", func(t *testing.T) {
 		expectedExamples := []string{
-			"kubectl oadp nonadmin bsl get", // Shows noun-first format from underlying command
+			"oc oadp nonadmin bsl get", // Shows noun-first format from underlying command
 		}
 
 		testutil.TestHelpCommand(t, binaryPath,
@@ -303,7 +303,7 @@ func TestVerbNounOrderBSLExamples(t *testing.T) {
 
 	t.Run("create bsl with specific resource shows proper examples", func(t *testing.T) {
 		expectedExamples := []string{
-			"kubectl oadp nonadmin bsl create", // Shows noun-first format from underlying command
+			"oc oadp nonadmin bsl create", // Shows noun-first format from underlying command
 		}
 
 		testutil.TestHelpCommand(t, binaryPath,

--- a/cmd/non-admin/bsl/create.go
+++ b/cmd/non-admin/bsl/create.go
@@ -49,14 +49,14 @@ func NewCreateCommand(f client.Factory, use string) *cobra.Command {
 			cmd.CheckError(o.Run(c, f))
 		},
 		Example: `  # Create a non-admin backup storage location for AWS
-  kubectl oadp nonadmin bsl create my-storage \
+  oc oadp nonadmin bsl create my-storage \
     --provider aws \
     --bucket my-velero-bucket \
     --credential cloud-credentials=cloud \
     --region us-east-1
 
   # Create with prefix for organizing backups
-  kubectl oadp nonadmin bsl create my-storage \
+  oc oadp nonadmin bsl create my-storage \
     --provider aws \
     --bucket my-velero-bucket \
     --prefix velero-backups \
@@ -64,14 +64,14 @@ func NewCreateCommand(f client.Factory, use string) *cobra.Command {
     --region us-east-1
 
   # Create with custom credential key
-  kubectl oadp nonadmin bsl create my-storage \
+  oc oadp nonadmin bsl create my-storage \
     --provider aws \
     --bucket my-velero-bucket \
     --credential my-secret=service-account-key \
     --region us-east-1
 
   # View the YAML without creating the resource
-  kubectl oadp nonadmin bsl create my-storage \
+  oc oadp nonadmin bsl create my-storage \
     --provider aws \
     --bucket my-bucket \
     --credential cloud-credentials=cloud \

--- a/cmd/non-admin/bsl/get.go
+++ b/cmd/non-admin/bsl/get.go
@@ -88,16 +88,16 @@ func NewGetCommand(f client.Factory, use string) *cobra.Command {
 			}
 		},
 		Example: `  # Get all non-admin backup storage locations in the current namespace
-  kubectl oadp nonadmin bsl get
+  oc oadp nonadmin bsl get
 
   # Get a specific non-admin backup storage location
-  kubectl oadp nonadmin bsl get my-storage
+  oc oadp nonadmin bsl get my-storage
 
   # Get backup storage locations in YAML format
-  kubectl oadp nonadmin bsl get -o yaml
+  oc oadp nonadmin bsl get -o yaml
 
   # Get a specific backup storage location in JSON format
-  kubectl oadp nonadmin bsl get my-storage -o json`,
+  oc oadp nonadmin bsl get my-storage -o json`,
 	}
 
 	output.BindFlags(c.Flags())

--- a/cmd/non-admin/restore/create.go
+++ b/cmd/non-admin/restore/create.go
@@ -46,22 +46,22 @@ func NewCreateCommand(f client.Factory, use string) *cobra.Command {
 			cmd.CheckError(o.Run(c, f))
 		},
 		Example: `  # Create a non-admin restore from a backup (auto-generated name).
-  kubectl oadp nonadmin restore create --backup-name backup1
+  oc oadp nonadmin restore create --backup-name backup1
 
   # Create a non-admin restore with a specific name.
-  kubectl oadp nonadmin restore create restore1 --backup-name backup1
+  oc oadp nonadmin restore create restore1 --backup-name backup1
 
   # Create a non-admin restore with specific resource types.
-  kubectl oadp nonadmin restore create restore2 --backup-name backup1 --include-resources deployments,services
+  oc oadp nonadmin restore create restore2 --backup-name backup1 --include-resources deployments,services
 
   # Create a non-admin restore excluding certain resources.
-  kubectl oadp nonadmin restore create restore3 --backup-name backup1 --exclude-resources secrets
+  oc oadp nonadmin restore create restore3 --backup-name backup1 --exclude-resources secrets
 
   # Create a non-admin restore with label selector.
-  kubectl oadp nonadmin restore create restore4 --backup-name backup1 --selector app=myapp
+  oc oadp nonadmin restore create restore4 --backup-name backup1 --selector app=myapp
 
   # View the YAML for a non-admin restore without sending it to the server.
-  kubectl oadp nonadmin restore create restore5 --backup-name backup1 -o yaml`,
+  oc oadp nonadmin restore create restore5 --backup-name backup1 -o yaml`,
 	}
 
 	o.BindFlags(c.Flags())

--- a/cmd/non-admin/restore/delete.go
+++ b/cmd/non-admin/restore/delete.go
@@ -58,16 +58,16 @@ func NewDeleteCommand(f client.Factory, use string) *cobra.Command {
 			cmd.CheckError(o.Run())
 		},
 		Example: `  # Delete a specific restore
-  kubectl oadp nonadmin restore delete my-restore
+  oc oadp nonadmin restore delete my-restore
 
   # Delete multiple restores
-  kubectl oadp nonadmin restore delete restore1 restore2 restore3
+  oc oadp nonadmin restore delete restore1 restore2 restore3
 
   # Delete all restores in the current namespace
-  kubectl oadp nonadmin restore delete --all
+  oc oadp nonadmin restore delete --all
 
   # Delete without confirmation prompt
-  kubectl oadp nonadmin restore delete my-restore --confirm`,
+  oc oadp nonadmin restore delete my-restore --confirm`,
 	}
 
 	o.BindFlags(c.Flags())

--- a/cmd/non-admin/restore/describe.go
+++ b/cmd/non-admin/restore/describe.go
@@ -81,9 +81,9 @@ func NewDescribeCommand(f client.Factory, use string) *cobra.Command {
 
 			return nil
 		},
-		Example: `  kubectl oadp nonadmin restore describe my-restore
-  kubectl oadp nonadmin restore describe my-restore --details
-  kubectl oadp nonadmin restore describe my-restore --details --request-timeout=30m`,
+		Example: `  oc oadp nonadmin restore describe my-restore
+  oc oadp nonadmin restore describe my-restore --details
+  oc oadp nonadmin restore describe my-restore --details --request-timeout=30m`,
 	}
 
 	c.Flags().DurationVar(&requestTimeout, "request-timeout", 0, fmt.Sprintf("The length of time to wait before giving up on a single server request (e.g., 30s, 5m, 1h). Overrides %s env var. Default: %v", shared.TimeoutEnvVar, shared.DefaultHTTPTimeout))

--- a/cmd/non-admin/restore/get.go
+++ b/cmd/non-admin/restore/get.go
@@ -87,16 +87,16 @@ func NewGetCommand(f client.Factory, use string) *cobra.Command {
 			}
 		},
 		Example: `  # Get all non-admin restores in the current namespace
-  kubectl oadp nonadmin restore get
+  oc oadp nonadmin restore get
 
   # Get a specific non-admin restore
-  kubectl oadp nonadmin restore get my-restore
+  oc oadp nonadmin restore get my-restore
 
   # Get restores in YAML format
-  kubectl oadp nonadmin restore get -o yaml
+  oc oadp nonadmin restore get -o yaml
 
   # Get a specific restore in JSON format
-  kubectl oadp nonadmin restore get my-restore -o json`,
+  oc oadp nonadmin restore get my-restore -o json`,
 	}
 
 	output.BindFlags(c.Flags())

--- a/cmd/non-admin/restore/logs.go
+++ b/cmd/non-admin/restore/logs.go
@@ -135,8 +135,8 @@ func NewLogsCommand(f client.Factory, use string) *cobra.Command {
 
 			return nil
 		},
-		Example: `  kubectl oadp nonadmin restore logs my-restore
-  kubectl oadp nonadmin restore logs my-restore --request-timeout=30m`,
+		Example: `  oc oadp nonadmin restore logs my-restore
+  oc oadp nonadmin restore logs my-restore --request-timeout=30m`,
 	}
 
 	c.Flags().DurationVar(&requestTimeout, "request-timeout", 0, fmt.Sprintf("The length of time to wait before giving up on a single server request (e.g., 30s, 5m, 1h). Overrides %s env var. Default: %v", shared.TimeoutEnvVar, shared.DefaultHTTPTimeout))

--- a/cmd/non-admin/restore/restore_test.go
+++ b/cmd/non-admin/restore/restore_test.go
@@ -185,7 +185,7 @@ func TestNonAdminRestoreExamples(t *testing.T) {
 
 	t.Run("create examples use correct command format", func(t *testing.T) {
 		expectedExamples := []string{
-			"kubectl oadp nonadmin restore create",
+			"oc oadp nonadmin restore create",
 			"--backup-name",
 			"--include-resources",
 			"--selector",
@@ -291,13 +291,13 @@ func TestVerbNounOrderRestoreExamples(t *testing.T) {
 	binaryPath := testutil.BuildCLIBinary(t)
 
 	t.Run("verb commands show proper examples", func(t *testing.T) {
-		// Test that verb commands show examples with kubectl oadp prefix
+		// Test that verb commands show examples with oc oadp prefix
 		expectedExamples := []string{
-			"kubectl oadp nonadmin get restore",
-			"kubectl oadp nonadmin create restore",
-			"kubectl oadp nonadmin describe restore",
-			"kubectl oadp nonadmin logs restore",
-			"kubectl oadp nonadmin delete restore",
+			"oc oadp nonadmin get restore",
+			"oc oadp nonadmin create restore",
+			"oc oadp nonadmin describe restore",
+			"oc oadp nonadmin logs restore",
+			"oc oadp nonadmin delete restore",
 		}
 
 		commands := [][]string{
@@ -316,11 +316,11 @@ func TestVerbNounOrderRestoreExamples(t *testing.T) {
 	t.Run("verb commands with specific resources show proper examples", func(t *testing.T) {
 		// Test that verb commands with specific resources show examples (noun-first format from underlying commands)
 		expectedExamples := []string{
-			"kubectl oadp nonadmin restore get",
-			"kubectl oadp nonadmin restore create",
-			"kubectl oadp nonadmin restore describe my-restore",
-			"kubectl oadp nonadmin restore logs my-restore",
-			"kubectl oadp nonadmin restore delete my-restore",
+			"oc oadp nonadmin restore get",
+			"oc oadp nonadmin restore create",
+			"oc oadp nonadmin restore describe my-restore",
+			"oc oadp nonadmin restore logs my-restore",
+			"oc oadp nonadmin restore delete my-restore",
 		}
 
 		commands := [][]string{
@@ -339,11 +339,11 @@ func TestVerbNounOrderRestoreExamples(t *testing.T) {
 	t.Run("shorthand verb commands show proper examples", func(t *testing.T) {
 		// Test that shorthand verb commands show examples
 		expectedExamples := []string{
-			"kubectl oadp nonadmin get restore",
-			"kubectl oadp nonadmin create restore",
-			"kubectl oadp nonadmin describe restore",
-			"kubectl oadp nonadmin logs restore",
-			"kubectl oadp nonadmin delete restore",
+			"oc oadp nonadmin get restore",
+			"oc oadp nonadmin create restore",
+			"oc oadp nonadmin describe restore",
+			"oc oadp nonadmin logs restore",
+			"oc oadp nonadmin delete restore",
 		}
 
 		commands := [][]string{
@@ -512,9 +512,9 @@ func TestNonAdminRestoreDeleteAllFlag(t *testing.T) {
 	t.Run("delete help has examples section", func(t *testing.T) {
 		// Test that examples section exists and shows various delete patterns
 		expectedExamples := []string{
-			"kubectl oadp nonadmin restore delete my-restore",
-			"kubectl oadp nonadmin restore delete --all",
-			"kubectl oadp nonadmin restore delete my-restore --confirm",
+			"oc oadp nonadmin restore delete my-restore",
+			"oc oadp nonadmin restore delete --all",
+			"oc oadp nonadmin restore delete my-restore --confirm",
 		}
 
 		testutil.TestHelpCommand(t, binaryPath,

--- a/cmd/non-admin/verbs/verbs.go
+++ b/cmd/non-admin/verbs/verbs.go
@@ -32,22 +32,22 @@ func NewGetCommand(factory client.Factory) *cobra.Command {
 		Short: "Get one or more non-admin resources",
 		Long:  "Get one or more non-admin resources. This is a verb-based command that delegates to the appropriate noun command.",
 		Example: `  # Get all non-admin backups
-  kubectl oadp nonadmin get backup
+  oc oadp nonadmin get backup
 
   # Get a specific non-admin backup
-  kubectl oadp nonadmin get backup my-backup
+  oc oadp nonadmin get backup my-backup
 
   # Get all non-admin restores
-  kubectl oadp nonadmin get restore
+  oc oadp nonadmin get restore
 
   # Get a specific non-admin restore
-  kubectl oadp nonadmin get restore my-restore
+  oc oadp nonadmin get restore my-restore
 
   # Get all non-admin backup storage locations
-  kubectl oadp nonadmin get bsl
+  oc oadp nonadmin get bsl
 
   # Get a specific backup storage location
-  kubectl oadp nonadmin get bsl my-storage`,
+  oc oadp nonadmin get bsl my-storage`,
 	}
 
 	c.AddCommand(
@@ -66,13 +66,13 @@ func NewCreateCommand(factory client.Factory) *cobra.Command {
 		Short: "Create non-admin resources",
 		Long:  "Create non-admin resources. This is a verb-based command that delegates to the appropriate noun command.",
 		Example: `  # Create a non-admin backup
-  kubectl oadp nonadmin create backup my-backup
+  oc oadp nonadmin create backup my-backup
 
   # Create a non-admin restore
-  kubectl oadp nonadmin create restore my-restore --backup-name my-backup
+  oc oadp nonadmin create restore my-restore --backup-name my-backup
 
   # Create a backup storage location
-  kubectl oadp nonadmin create bsl my-bsl`,
+  oc oadp nonadmin create bsl my-bsl`,
 	}
 
 	c.AddCommand(
@@ -91,10 +91,10 @@ func NewDeleteCommand(factory client.Factory) *cobra.Command {
 		Short: "Delete non-admin resources",
 		Long:  "Delete non-admin resources. This is a verb-based command that delegates to the appropriate noun command.",
 		Example: `  # Delete a non-admin backup
-  kubectl oadp nonadmin delete backup my-backup
+  oc oadp nonadmin delete backup my-backup
 
   # Delete a non-admin restore
-  kubectl oadp nonadmin delete restore my-restore`,
+  oc oadp nonadmin delete restore my-restore`,
 	}
 
 	c.AddCommand(
@@ -112,10 +112,10 @@ func NewDescribeCommand(factory client.Factory) *cobra.Command {
 		Short: "Describe non-admin resources",
 		Long:  "Describe non-admin resources. This is a verb-based command that delegates to the appropriate noun command.",
 		Example: `  # Describe a non-admin backup
-  kubectl oadp nonadmin describe backup my-backup
+  oc oadp nonadmin describe backup my-backup
 
   # Describe a non-admin restore
-  kubectl oadp nonadmin describe restore my-restore`,
+  oc oadp nonadmin describe restore my-restore`,
 	}
 
 	c.AddCommand(
@@ -133,10 +133,10 @@ func NewLogsCommand(factory client.Factory) *cobra.Command {
 		Short: "Get logs for non-admin resources",
 		Long:  "Get logs for non-admin resources. This is a verb-based command that delegates to the appropriate noun command.",
 		Example: `  # Get logs for a non-admin backup
-  kubectl oadp nonadmin logs backup my-backup
+  oc oadp nonadmin logs backup my-backup
 
   # Get logs for a non-admin restore
-  kubectl oadp nonadmin logs restore my-restore`,
+  oc oadp nonadmin logs restore my-restore`,
 	}
 
 	c.AddCommand(

--- a/cmd/shared/download.go
+++ b/cmd/shared/download.go
@@ -38,7 +38,7 @@ import (
 const DefaultHTTPTimeout = 10 * time.Minute
 
 // TimeoutEnvVar is the environment variable name that can be used to override the default timeout.
-// Example: OADP_CLI_REQUEST_TIMEOUT=30m kubectl oadp nonadmin backup logs my-backup
+// Example: OADP_CLI_REQUEST_TIMEOUT=30m oc oadp nonadmin backup logs my-backup
 const TimeoutEnvVar = "OADP_CLI_REQUEST_TIMEOUT"
 
 // getHTTPTimeout returns the HTTP timeout to use for download operations.


### PR DESCRIPTION
## Why the changes were made

Fixes https://github.com/migtools/oadp-cli/issues/122
All non-admin and nabsl-request commands had kubectl oadp hardcoded in their help/example sections, while every other CLI command consistently uses oc oadp. Since OADP is primarily used on OpenShift, the examples should uniformly show oc oadp as the CLI prefix.
Replaced kubectl oadp → oc oadp in the Example strings of 18 source files across cmd/non-admin/ (backup, restore, bsl, verbs) and cmd/nabsl-request/ (nabsl, get, approve, reject, describe), along with 3 corresponding test files and 1 code comment in cmd/shared/download.go.


## How to test the changes made

make build

# Noun-first style commands
oc oadp nonadmin backup create -h
oc oadp nonadmin backup get -h
oc oadp nonadmin backup describe -h
oc oadp nonadmin backup logs -h
oc oadp nonadmin backup delete -h
oc oadp nonadmin restore create -h
oc oadp nonadmin restore get -h
oc oadp nonadmin restore describe -h
oc oadp nonadmin restore logs -h
oc oadp nonadmin restore delete -h
oc oadp nonadmin bsl create -h
oc oadp nonadmin bsl get -h

# Verb-first style commands
oc oadp nonadmin get -h
oc oadp nonadmin create -h
oc oadp nonadmin delete -h
oc oadp nonadmin describe -h
oc oadp nonadmin logs -h

# NABSL-request commands
oc oadp nabsl-request -h
oc oadp nabsl-request get -h
oc oadp nabsl-request approve -h
oc oadp nabsl-request reject -h
oc oadp nabsl-request describe -h


All examples should show oc oadp instead of kubectl oadp. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CLI help and example text across the product to use "oc" instead of "kubectl" for all command examples (backup, restore, non-admin, request-related commands).
  * Aligned test expectations and inline usage comments to match the updated example text so documentation and tests are consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->