### PR TITLE
fixed panic in describe output while displaying Hooksattempted or fai…

### DIFF
--- a/cmd/non-admin/backup/describe.go
+++ b/cmd/non-admin/backup/describe.go
@@ -372,8 +372,13 @@ func printNonAdminBackupDetails(cmd *cobra.Command, nab *nacv1alpha1.NonAdminBac
 		fmt.Fprintf(out, "\n")
 
 		// Hooks
-		fmt.Fprintf(out, "HooksAttempted:  %d\n", status.HookStatus.HooksAttempted)
-		fmt.Fprintf(out, "HooksFailed:     %d\n", status.HookStatus.HooksFailed)
+		if status.HookStatus != nil {
+			fmt.Fprintf(out, "HooksAttempted:  %d\n", status.HookStatus.HooksAttempted)
+			fmt.Fprintf(out, "HooksFailed:     %d\n", status.HookStatus.HooksFailed)
+		} else {
+			fmt.Fprintf(out, "HooksAttempted:  <none>\n")
+			fmt.Fprintf(out, "HooksFailed:     <none>\n")
+		}
 	} else {
 		// Velero backup not available yet
 		fmt.Fprintf(out, "Velero backup information not yet available.\n")

--- a/cmd/non-admin/restore/describe.go
+++ b/cmd/non-admin/restore/describe.go
@@ -317,8 +317,13 @@ func printNonAdminRestoreDetails(cmd *cobra.Command, nar *nacv1alpha1.NonAdminRe
 		fmt.Fprintf(out, "\n")
 
 		// Hooks
-		fmt.Fprintf(out, "HooksAttempted:  %d\n", status.HookStatus.HooksAttempted)
-		fmt.Fprintf(out, "HooksFailed:     %d\n", status.HookStatus.HooksFailed)
+		if status.HookStatus != nil {
+			fmt.Fprintf(out, "HooksAttempted:  %d\n", status.HookStatus.HooksAttempted)
+			fmt.Fprintf(out, "HooksFailed:     %d\n", status.HookStatus.HooksFailed)
+		} else {
+			fmt.Fprintf(out, "HooksAttempted:  <none>\n")
+			fmt.Fprintf(out, "HooksFailed:     <none>\n")
+		}
 	} else {
 		// Velero restore not available yet
 		fmt.Fprintf(out, "Velero restore information not yet available.\n")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -777,8 +777,8 @@ func TestApplyTimeoutToConfig_DialerTimeout(t *testing.T) {
 	}
 
 	// Should complete within a reasonable time of the timeout
-	// Allow some margin for test execution overhead
-	maxExpected := timeout + 500*time.Millisecond
+	// Allow some margin for test execution overhead and system load variations
+	maxExpected := timeout + 1*time.Second
 	if elapsed > maxExpected {
 		t.Errorf("Dial took too long: %v (expected ~%v)", elapsed, timeout)
 	}


### PR DESCRIPTION
## Why the changes were made

Fixed #133 
The oadp nonadmin backup describe and oadp nonadmin restore describe commands panic with a nil pointer dereference when the backup/restore is still InProgress (or any state where hooks haven't executed yet).
The root cause is that status.HookStatus is a pointer (*HookStatus) which is nil until hooks have actually run. The code was accessing status.HookStatus.HooksAttempted and status.HookStatus.HooksFailed without a nil check, causing a SIGSEGV crash:

`panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x10442d39c]

goroutine 1 [running]:
github.com/migtools/oadp-cli/cmd/non-admin/backup.printNonAdminBackupDetails(...)
	/Users/ssingla/Documents/git_workdir/oadp-cli/cmd/non-admin/backup/describe.go:375 +0xfac`

## How to test the changes made

Install the OADP CLI using "make install" first.

1. Create a non-admin backup and immediately run describe while it is still InProgress:

`# In a non-admin namespace
oc create secret generic cloud-credentials --from-file=cloud=credentials
oc oadp nonadmin bsl create test-bsl --provider gcp --bucket <bucket-name> --credential cloud-credentials=cloud
oc oadp nonadmin backup create backup1 --default-volumes-to-fs-backup=true --storage-location test-bsl

Run describe while backup is InProgress — **this previously panicked**

oc oadp nonadmin backup describe backup1
oc oadp nonadmin backup describe backup1 --details`

2. Verify the output no longer panics and instead displays:

`HooksAttempted:  <none>
HooksFailed:     <none>`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when showing backup/restore hook status by safely displaying hook fields as "none" when data is missing.

* **Tests**
  * Increased timing tolerance in a connection timeout test to account for system load variability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->