### PR TITLE
add bsl status to nonadmn bsl get

### DIFF
--- a/cmd/non-admin/bsl/get.go
+++ b/cmd/non-admin/bsl/get.go
@@ -113,16 +113,17 @@ func printNonAdminBSLTable(nabslList *nacv1alpha1.NonAdminBackupStorageLocationL
 	}
 
 	// Print header
-	fmt.Printf("%-30s %-15s %-15s %-20s %-10s\n", "NAME", "REQUEST PHASE", "PROVIDER", "BUCKET/PREFIX", "AGE")
+	fmt.Printf("%-30s %-15s %-15s %-15s %-20s %-10s\n", "NAME", "REQUEST PHASE", "VELERO PHASE", "PROVIDER", "BUCKET/PREFIX", "AGE")
 
 	// Print each BSL
 	for _, nabsl := range nabslList.Items {
 		status := getBSLStatus(&nabsl)
+		veleroPhase := getBSLVeleroPhase(&nabsl)
 		provider := getProvider(&nabsl)
 		bucketPrefix := getBucketPrefix(&nabsl)
 		age := formatAge(nabsl.CreationTimestamp.Time)
 
-		fmt.Printf("%-30s %-15s %-15s %-20s %-10s\n", nabsl.Name, status, provider, bucketPrefix, age)
+		fmt.Printf("%-30s %-15s %-15s %-15s %-20s %-10s\n", nabsl.Name, status, veleroPhase, provider, bucketPrefix, age)
 	}
 
 	return nil
@@ -133,6 +134,15 @@ func getBSLStatus(nabsl *nacv1alpha1.NonAdminBackupStorageLocation) string {
 		return string(nabsl.Status.Phase)
 	}
 	return "Unknown"
+}
+
+func getBSLVeleroPhase(nabsl *nacv1alpha1.NonAdminBackupStorageLocation) string {
+	if nabsl.Status.VeleroBackupStorageLocation != nil && nabsl.Status.VeleroBackupStorageLocation.Status != nil {
+		if nabsl.Status.VeleroBackupStorageLocation.Status.Phase != "" {
+			return string(nabsl.Status.VeleroBackupStorageLocation.Status.Phase)
+		}
+	}
+	return "N/A"
 }
 
 func getProvider(nabsl *nacv1alpha1.NonAdminBackupStorageLocation) string {


### PR DESCRIPTION
## Why the changes were made

fixes: https://github.com/migtools/oadp-cli/issues/131

## How to test the changes made

```
oc oadp nonadmin bsl get
NAME                           REQUEST PHASE   VELERO PHASE    PROVIDER        BUCKET/PREFIX        AGE       
nacuser1                       Created         Available       aws             wesoadpnacuser1/velero 20h   
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new "VELERO PHASE" column to the Backup Storage Location table, displaying the phase status of each backup storage location. Shows "N/A" when status information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->