### PR TITLE
Nonadmin only

### DIFF
--- a/cmd/non-admin/bsl/get.go
+++ b/cmd/non-admin/bsl/get.go
@@ -113,16 +113,17 @@ func printNonAdminBSLTable(nabslList *nacv1alpha1.NonAdminBackupStorageLocationL
 	}
 
 	// Print header
-	fmt.Printf("%-30s %-15s %-15s %-20s %-10s\n", "NAME", "REQUEST PHASE", "PROVIDER", "BUCKET/PREFIX", "AGE")
+	fmt.Printf("%-30s %-15s %-15s %-15s %-20s %-10s\n", "NAME", "REQUEST PHASE", "VELERO PHASE", "PROVIDER", "BUCKET/PREFIX", "AGE")
 
 	// Print each BSL
 	for _, nabsl := range nabslList.Items {
 		status := getBSLStatus(&nabsl)
+		veleroPhase := getBSLVeleroPhase(&nabsl)
 		provider := getProvider(&nabsl)
 		bucketPrefix := getBucketPrefix(&nabsl)
 		age := formatAge(nabsl.CreationTimestamp.Time)
 
-		fmt.Printf("%-30s %-15s %-15s %-20s %-10s\n", nabsl.Name, status, provider, bucketPrefix, age)
+		fmt.Printf("%-30s %-15s %-15s %-15s %-20s %-10s\n", nabsl.Name, status, veleroPhase, provider, bucketPrefix, age)
 	}
 
 	return nil
@@ -133,6 +134,15 @@ func getBSLStatus(nabsl *nacv1alpha1.NonAdminBackupStorageLocation) string {
 		return string(nabsl.Status.Phase)
 	}
 	return "Unknown"
+}
+
+func getBSLVeleroPhase(nabsl *nacv1alpha1.NonAdminBackupStorageLocation) string {
+	if nabsl.Status.VeleroBackupStorageLocation != nil && nabsl.Status.VeleroBackupStorageLocation.Status != nil {
+		if nabsl.Status.VeleroBackupStorageLocation.Status.Phase != "" {
+			return string(nabsl.Status.VeleroBackupStorageLocation.Status.Phase)
+		}
+	}
+	return "N/A"
 }
 
 func getProvider(nabsl *nacv1alpha1.NonAdminBackupStorageLocation) string {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -462,8 +462,8 @@ func NewVeleroRootCommand(baseName string) *cobra.Command {
 		renameTimeoutFlag(cmd)
 	}
 
-	// When nonadmin mode is enabled, hide all admin commands so only
-	// nonadmin and client (for toggling the config) are visible.
+	// When nonadmin mode is enabled, remove all admin commands so only
+	// nonadmin, client (for toggling the config), and help are available.
 	if isNonadminEnabled(config) {
 		allowedCmds := map[string]bool{
 			"nonadmin":   true,
@@ -472,7 +472,7 @@ func NewVeleroRootCommand(baseName string) *cobra.Command {
 		}
 		for _, cmd := range c.Commands() {
 			if !allowedCmds[cmd.Use] {
-				cmd.Hidden = true
+				c.RemoveCommand(cmd)
 			}
 		}
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,7 +49,7 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/cmd/cli/create"
 	"github.com/vmware-tanzu/velero/pkg/cmd/cli/datamover"
 	"github.com/vmware-tanzu/velero/pkg/cmd/cli/debug"
-	"github.com/vmware-tanzu/velero/pkg/cmd/cli/delete"
+	veldelete "github.com/vmware-tanzu/velero/pkg/cmd/cli/delete"
 	"github.com/vmware-tanzu/velero/pkg/cmd/cli/describe"
 	"github.com/vmware-tanzu/velero/pkg/cmd/cli/get"
 	"github.com/vmware-tanzu/velero/pkg/cmd/cli/repo"
@@ -349,12 +349,37 @@ func wrapPreRunE(existing func(*cobra.Command, []string) error, additional func(
 	}
 }
 
+// isNonadminEnabled checks if nonadmin mode is enabled in the VeleroConfig.
+// Handles both boolean and string representations since
+// `oc oadp client config set nonadmin=true` stores the value as a string.
+func isNonadminEnabled(config clientcmd.VeleroConfig) bool {
+	val, ok := config["nonadmin"]
+	if !ok {
+		return false
+	}
+	switch v := val.(type) {
+	case bool:
+		return v
+	case string:
+		return strings.EqualFold(v, "true")
+	default:
+		return false
+	}
+}
+
 // NewVeleroRootCommand returns a root command with all Velero CLI subcommands attached.
 func NewVeleroRootCommand(baseName string) *cobra.Command {
 
 	config, err := clientcmd.LoadConfig()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "WARNING: Error reading config file: %v\n", err)
+	}
+
+	// When nonadmin mode is enabled, remove the namespace override so the
+	// factory uses the current kubeconfig context namespace instead of an
+	// admin namespace like openshift-adp.
+	if isNonadminEnabled(config) {
+		delete(config, clientcmd.ConfigKeyNamespace)
 	}
 
 	// Declare cmdFeatures and cmdColorzied here so we can access them in the PreRun hooks
@@ -401,7 +426,7 @@ func NewVeleroRootCommand(baseName string) *cobra.Command {
 		get.NewCommand(f),
 		describe.NewCommand(f),
 		create.NewCommand(f),
-		delete.NewCommand(f),
+		veldelete.NewCommand(f),
 		cliclient.NewCommand(),
 		completion.NewCommand(),
 		repo.NewCommand(f),
@@ -435,6 +460,21 @@ func NewVeleroRootCommand(baseName string) *cobra.Command {
 	// Rename --timeout flags to --request-timeout for kubectl consistency
 	for _, cmd := range c.Commands() {
 		renameTimeoutFlag(cmd)
+	}
+
+	// When nonadmin mode is enabled, hide all admin commands so only
+	// nonadmin and client (for toggling the config) are visible.
+	if isNonadminEnabled(config) {
+		allowedCmds := map[string]bool{
+			"nonadmin":   true,
+			"client":     true,
+			"completion": true,
+		}
+		for _, cmd := range c.Commands() {
+			if !allowedCmds[cmd.Use] {
+				cmd.Hidden = true
+			}
+		}
 	}
 
 	// Set custom usage template to show "oc oadp" instead of just "oadp"

--- a/cmd/shared/factories.go
+++ b/cmd/shared/factories.go
@@ -21,13 +21,32 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/vmware-tanzu/velero/pkg/client"
 )
 
 // ClientConfig represents the structure of the Velero client configuration file
 type ClientConfig struct {
-	Namespace string `json:"namespace"`
+	Namespace string      `json:"namespace"`
+	NonAdmin  interface{} `json:"nonadmin,omitempty"`
+}
+
+// IsNonAdmin returns true if the nonadmin configuration is enabled.
+// Handles both boolean and string representations since
+// `oc oadp client config set nonadmin=true` stores the value as a string.
+func (c *ClientConfig) IsNonAdmin() bool {
+	if c == nil {
+		return false
+	}
+	switch v := c.NonAdmin.(type) {
+	case bool:
+		return v
+	case string:
+		return strings.EqualFold(v, "true")
+	default:
+		return false
+	}
 }
 
 // CreateVeleroFactory creates a client factory for Velero operations (admin-scoped)


### PR DESCRIPTION
## Why the changes were made

fixes: https://github.com/migtools/oadp-cli/issues/128

## How to test the changes made

```
oc oadp client config set nonadmin=true
```

* now the user should only have access to: client, help and nonadmin :)
```
nacuser1@fedora:~/git/oadp-cli$ oc oadp --help
OADP CLI commands

Usage:
  oc oadp [flags]
  oc oadp [command]

Available Commands:
  client            Velero client related commands
  help              Help about any command
  nonadmin          Work with non-admin resources

Flags:
      --add_dir_header                   If true, adds the file directory to the header of the log messages
      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
  -h, --help                             help for oadp
      --kubeconfig string                Path to the kubeconfig file to use to talk to the Kubernetes apiserver. If unset, try the environment variable KUBECONFIG, as well as in-cluster configuration
      --kubecontext string               The context to use to talk to the Kubernetes apiserver. If unset defaults to whatever your current-co
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Velero Phase column to non-admin Backup Storage Location table for improved status visibility.
  * Implemented non-admin mode configuration support that selectively hides admin commands at runtime.
  * Client configuration extended to detect and manage non-admin mode from flexible value types.
  * Non-admin behavior now respects configured namespace handling to use the active kubeconfig namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->