### PR TITLE
fix bsl message

### DIFF
--- a/cmd/non-admin/bsl/create.go
+++ b/cmd/non-admin/bsl/create.go
@@ -200,6 +200,5 @@ func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
 
 	fmt.Printf("NonAdminBackupStorageLocation %q created successfully.\n", nabsl.Name)
 	fmt.Printf("The controller will create a request for admin approval.\n")
-	fmt.Printf("Use 'oc oadp nonadmin bsl request get' to view auto-created requests.\n")
 	return nil
 }


### PR DESCRIPTION
## Why the changes were made

fixes: https://github.com/migtools/oadp-cli/issues/136

## How to test the changes made

```
oc oadp nonadmin bsl create test-bsl2 --provider aws --bucket wesoadpnacuser1 --prefix=sachin2 --credential cloud-credentials=cloud
NonAdminBackupStorageLocation "test-bsl2" created successfully.
The controller will create a request for admin approval.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an informational message that previously prompted users to run a command to view auto-created resource requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->