### PR TITLE
Add config support default non-admin storage location

### DIFF
--- a/cmd/non-admin/backup/create.go
+++ b/cmd/non-admin/backup/create.go
@@ -79,9 +79,10 @@ type CreateOptions struct {
 	*velerobackup.CreateOptions // Embed Velero's CreateOptions
 
 	// NAB-specific fields
-	Name             string // The NonAdminBackup resource name (maps to Velero's BackupName)
-	client           kbclient.WithWatch
-	currentNamespace string
+	Name                      string // The NonAdminBackup resource name (maps to Velero's BackupName)
+	client                    kbclient.WithWatch
+	currentNamespace          string
+	storageLocationFromConfig bool // Track if storage location came from config
 }
 
 func NewCreateOptions() *CreateOptions {
@@ -144,9 +145,13 @@ func (o *CreateOptions) Validate(c *cobra.Command, args []string, f client.Facto
 func (o *CreateOptions) Complete(args []string, f client.Factory) error {
 	o.Name = args[0]
 
-	defaultNABSL := getNABSLFromConfig()
-	if defaultNABSL != "" {
-		o.StorageLocation = defaultNABSL
+	// Load default NABSL from config if not provided via flag
+	if o.StorageLocation == "" {
+		defaultNABSL := getNABSLFromConfig()
+		if defaultNABSL != "" {
+			o.StorageLocation = defaultNABSL
+			o.storageLocationFromConfig = true
+		}
 	}
 
 	// Create client with NonAdmin scheme
@@ -183,8 +188,8 @@ func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
 		return err
 	}
 
-	if defaultNABSL := getNABSLFromConfig(); defaultNABSL != "" {
-		fmt.Printf("Using default nonadmin backup storage location from config: %s\n", defaultNABSL)
+	if o.storageLocationFromConfig {
+		fmt.Printf("Using default nonadmin backup storage location from config: %s\n", o.StorageLocation)
 	}
 
 	fmt.Printf("NonAdminBackup request %q submitted successfully.\n", nonAdminBackup.Name)

--- a/cmd/non-admin/backup/create.go
+++ b/cmd/non-admin/backup/create.go
@@ -61,6 +61,9 @@ func NewCreateCommand(f client.Factory, use string) *cobra.Command {
   # Create a backup with specific storage location.
   oc oadp nonadmin backup create backup5 --storage-location my-nabsl
 
+  # Set default storage location for all backups.
+  oc oadp client config set default-nabsl=my-nabsl
+
   # View the YAML for a backup without sending it to the server.
   oc oadp nonadmin backup create backup6 -o yaml`,
 	}
@@ -102,7 +105,7 @@ func (o *CreateOptions) BindFlags(flags *pflag.FlagSet) {
 
 	// Timing/Storage (MVP)
 	flags.DurationVar(&o.TTL, "ttl", o.TTL, "How long before the backup can be garbage collected.")
-	flags.StringVar(&o.StorageLocation, "storage-location", "", "Location in which to store the backup.")
+	flags.StringVar(&o.StorageLocation, "storage-location", "", "Location in which to store the backup. Uses config 'default-nabsl' if not specified.")
 	flags.DurationVar(&o.CSISnapshotTimeout, "csi-snapshot-timeout", o.CSISnapshotTimeout, "How long to wait for CSI snapshot creation before timeout.")
 	flags.DurationVar(&o.ItemOperationTimeout, "item-operation-timeout", o.ItemOperationTimeout, "How long to wait for async plugin operations before timeout.")
 
@@ -132,7 +135,7 @@ func (o *CreateOptions) Validate(c *cobra.Command, args []string, f client.Facto
 
 	// Storage location validation
 	if o.StorageLocation == "" {
-		return fmt.Errorf("--storage-location is required")
+		return fmt.Errorf("--storage-location is required (can be set via flag or config 'default-nabsl')")
 	}
 
 	return nil
@@ -140,6 +143,18 @@ func (o *CreateOptions) Validate(c *cobra.Command, args []string, f client.Facto
 
 func (o *CreateOptions) Complete(args []string, f client.Factory) error {
 	o.Name = args[0]
+
+	// Load default storage location from config if not provided via flag
+	if o.StorageLocation == "" {
+		clientConfig, err := shared.ReadVeleroClientConfig()
+		if err == nil && clientConfig != nil {
+			defaultNABSL := clientConfig.GetDefaultNABSL()
+			if defaultNABSL != "" {
+				o.StorageLocation = defaultNABSL
+			}
+		}
+		// Silently ignore config read errors - validation will catch missing storage location
+	}
 
 	// Create client with NonAdmin scheme
 	client, err := shared.NewClientWithScheme(f, shared.ClientOptions{

--- a/cmd/non-admin/backup/create.go
+++ b/cmd/non-admin/backup/create.go
@@ -186,8 +186,10 @@ func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
 	if defaultNABSL := getNABSLFromConfig(); defaultNABSL != "" {
 		fmt.Printf("Using default storage location from config: %s\n", defaultNABSL)
 	}
+
 	fmt.Printf("NonAdminBackup request %q submitted successfully.\n", nonAdminBackup.Name)
 	fmt.Printf("Run `oc oadp nonadmin backup describe %s` or `oc oadp nonadmin backup logs %s` for more details.\n", nonAdminBackup.Name, nonAdminBackup.Name)
+	fmt.Println()
 
 	return nil
 }

--- a/cmd/non-admin/backup/create.go
+++ b/cmd/non-admin/backup/create.go
@@ -136,7 +136,9 @@ func (o *CreateOptions) Validate(c *cobra.Command, args []string, f client.Facto
 
 	// Storage location validation
 	if o.StorageLocation == "" {
-		return fmt.Errorf("--storage-location is required (can be set via flag or config 'default-nabsl')")
+		return fmt.Errorf("--storage-location is required\n" +
+			"To avoid specifying the storage location each time:\n" +
+			"run `oc oadp client config set default-nabsl=<NABSL_NAME>` to set the default storage location")
 	}
 
 	return nil

--- a/cmd/non-admin/backup/create.go
+++ b/cmd/non-admin/backup/create.go
@@ -184,7 +184,7 @@ func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
 	}
 
 	if defaultNABSL := getNABSLFromConfig(); defaultNABSL != "" {
-		fmt.Printf("Using default storage location from config: %s\n", defaultNABSL)
+		fmt.Printf("Using default nonadmin backup storage location from config: %s\n", defaultNABSL)
 	}
 
 	fmt.Printf("NonAdminBackup request %q submitted successfully.\n", nonAdminBackup.Name)

--- a/cmd/non-admin/backup/create.go
+++ b/cmd/non-admin/backup/create.go
@@ -144,16 +144,9 @@ func (o *CreateOptions) Validate(c *cobra.Command, args []string, f client.Facto
 func (o *CreateOptions) Complete(args []string, f client.Factory) error {
 	o.Name = args[0]
 
-	// Load default storage location from config if not provided via flag
-	if o.StorageLocation == "" {
-		clientConfig, err := shared.ReadVeleroClientConfig()
-		if err == nil && clientConfig != nil {
-			defaultNABSL := clientConfig.GetDefaultNABSL()
-			if defaultNABSL != "" {
-				o.StorageLocation = defaultNABSL
-			}
-		}
-		// Silently ignore config read errors - validation will catch missing storage location
+	defaultNABSL := getNABSLFromConfig()
+	if defaultNABSL != "" {
+		o.StorageLocation = defaultNABSL
 	}
 
 	// Create client with NonAdmin scheme
@@ -190,8 +183,12 @@ func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
 		return err
 	}
 
+	if defaultNABSL := getNABSLFromConfig(); defaultNABSL != "" {
+		fmt.Printf("Using default storage location from config: %s\n", defaultNABSL)
+	}
 	fmt.Printf("NonAdminBackup request %q submitted successfully.\n", nonAdminBackup.Name)
 	fmt.Printf("Run `oc oadp nonadmin backup describe %s` or `oc oadp nonadmin backup logs %s` for more details.\n", nonAdminBackup.Name, nonAdminBackup.Name)
+
 	return nil
 }
 
@@ -251,4 +248,15 @@ func (o *CreateOptions) createNonAdminBackup(namespace string, backupSpec *veler
 			BackupSpec: backupSpec,
 		}).
 		Result()
+}
+
+func getNABSLFromConfig() string {
+	clientConfig, err := shared.ReadVeleroClientConfig()
+	if err == nil && clientConfig != nil {
+		defaultNABSL := clientConfig.GetDefaultNABSL()
+		if defaultNABSL != "" {
+			return defaultNABSL
+		}
+	}
+	return ""
 }

--- a/cmd/non-admin/bsl/create.go
+++ b/cmd/non-admin/bsl/create.go
@@ -199,8 +199,9 @@ func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
 	}
 
 	fmt.Printf("NonAdminBackupStorageLocation %q created successfully.\n", nabsl.Name)
-	fmt.Printf("The controller will create a request for admin approval.\n")
-	fmt.Printf("Use 'oc oadp nonadmin bsl request get' to view created requests.\n")
+	fmt.Println("The controller will create a request for admin approval.")
+	fmt.Println("Use 'oc oadp nonadmin bsl request get' to view created requests.")
 	fmt.Printf("Use `oc oadp client config set default-nabsl=%s` to set this BSL as the default to avoid specifying the BSL name each time.\n", nabsl.Name)
+	fmt.Println()
 	return nil
 }

--- a/cmd/non-admin/bsl/create.go
+++ b/cmd/non-admin/bsl/create.go
@@ -200,6 +200,7 @@ func (o *CreateOptions) Run(c *cobra.Command, f client.Factory) error {
 
 	fmt.Printf("NonAdminBackupStorageLocation %q created successfully.\n", nabsl.Name)
 	fmt.Printf("The controller will create a request for admin approval.\n")
-	fmt.Printf("Use 'oc oadp nonadmin bsl request get' to view auto-created requests.\n")
+	fmt.Printf("Use 'oc oadp nonadmin bsl request get' to view created requests.\n")
+	fmt.Printf("Use `oc oadp client config set default-nabsl=%s` to set this BSL as the default to avoid specifying the BSL name each time.\n", nabsl.Name)
 	return nil
 }

--- a/cmd/shared/factories.go
+++ b/cmd/shared/factories.go
@@ -28,8 +28,9 @@ import (
 
 // ClientConfig represents the structure of the Velero client configuration file
 type ClientConfig struct {
-	Namespace string      `json:"namespace"`
-	NonAdmin  interface{} `json:"nonadmin,omitempty"`
+	Namespace    string      `json:"namespace"`
+	NonAdmin     interface{} `json:"nonadmin,omitempty"`
+	DefaultNABSL string      `json:"default-nabsl,omitempty"`
 }
 
 // IsNonAdmin returns true if the nonadmin configuration is enabled.
@@ -47,6 +48,15 @@ func (c *ClientConfig) IsNonAdmin() bool {
 	default:
 		return false
 	}
+}
+
+// GetDefaultNABSL returns the default NonAdminBackupStorageLocation if set.
+// Returns empty string if not configured.
+func (c *ClientConfig) GetDefaultNABSL() string {
+	if c == nil {
+		return ""
+	}
+	return c.DefaultNABSL
 }
 
 // CreateVeleroFactory creates a client factory for Velero operations (admin-scoped)


### PR DESCRIPTION
## Why the changes were made

- Adds a new config value nonadmin-default: this allows nonadmin users to specify a default NABSL, allowing them to not specify --storage-location for each nonadmin backup creation
- Improve output formatting with line breaks and notification around the config value

## How to test the changes made

1. Create a NABSL (eg test-nabsl). A message around setting the config value should be visible.
2. Set the config value: `oc oadp nonadmin client config set default-nabsl=test-nabsl`
3. Run a nonadmin backup: `oc oadp nonadmin backup create test-backup`

The backup should be created successfully with a message stating that the config value was used for nonadmin backup storage location

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for a configurable default non-admin backup storage location so you no longer must specify it each time.

* **Bug Fixes / UX**
  * CLI help clarifies storage-location can be overridden by config.
  * Commands print a clear notice when the default storage location from config is used.
  * Minor wording tweak: references "created requests" and adds a hint to set a default via the client config.

* **Documentation**
  * Examples and help text updated to show setting and using the default storage location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->