### PR TITLE
fix bash on fedora

### DIFF
--- a/cmd/completion/install.go
+++ b/cmd/completion/install.go
@@ -147,11 +147,13 @@ func (o *InstallOptions) Run(c *cobra.Command) error {
 
 // isBashCompletionInstalled checks if bash-completion is available
 func (o *InstallOptions) isBashCompletionInstalled() bool {
-	// Check common bash-completion paths
+	// Check common bash-completion paths across Linux distros and macOS
 	paths := []string{
+		"/usr/share/bash-completion/bash_completion",
+		"/etc/bash_completion",
+		"/etc/profile.d/bash_completion.sh",
 		"/opt/homebrew/etc/bash_completion",
 		"/usr/local/etc/bash_completion",
-		"/etc/bash_completion",
 	}
 
 	for _, path := range paths {


### PR DESCRIPTION
## Why the changes were made

fixes: https://github.com/migtools/oadp-cli/issues/149


## How to test the changes made

```
whayutin@fedora:~/OPENSHIFT/git/OADP/oadp-cli$ make install
Building kubectl-oadp for current platform (linux/amd64)...
✅ Built kubectl-oadp successfully!
Installing kubectl-oadp to /home/whayutin/.local/bin...
✅ Installed to /home/whayutin/.local/bin

🔍 Checking PATH configuration...
   └─ ✅ /home/whayutin/.local/bin is already in PATH


📋 Configuration:

   🔍 Detecting OADP deployment in cluster...
   ├─ ✅ Found OADP controller in namespace: openshift-adp

   🔍 Looking for DataProtectionApplication (DPA) resources...
   ├─ ✅ Found DPA resource in namespace: openshift-adp

   ├─ Setting Velero namespace to: openshift-adp
   └─ ✅ Client config initialized

🧪 Verifying installation...
   ├─ ✅ Installation verified: kubectl oadp plugin is accessible
   └─ Running version command...

      Client:
      	Version: v0.3.3-44-gdac6316-dirty
      	Git commit: dac6316471354cd005dea3bf4cffe6cfa184aa7f-dirty
      Server:
      	Version: konveyor-dev

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🎉 Installation complete!

   Quick start:
   • oc oadp --help          # Show available commands
   • oc oadp backup get      # List backups
   • oc oadp version         # Show version info
whayutin@fedora:~/OPENSHIFT/git/OADP/oadp-cli$  oc oadp completion install --shell bash
Installing completions for bash...
✓ Completions files are already installed
Use --force to reinstall

✓ Setup complete! Your ~/.bashrc has bash-completion loaded.

Completions will work after restarting your shell:

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bash completion detection across Linux and macOS systems by expanding path checks to include common distribution-specific locations, ensuring more reliable completion installation across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->