### PR TITLE
Trigger Quay push on oadp-* branch pushes instead of tag pushes

### DIFF
--- a/.github/workflows/quay_binaries_push.yml
+++ b/.github/workflows/quay_binaries_push.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - 'oadp-*'
   pull_request:
+    branches:
+      - 'oadp-*'
 
 
 env:
@@ -58,7 +60,7 @@ jobs:
     name: Create and Push Multi-Arch Manifest
     runs-on: ubuntu-latest
     needs: multi-arch-build
-    if: startsWith(github.ref_name, 'oadp-')
+    if: github.event_name == 'push'
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -83,6 +85,7 @@ jobs:
           buildah tag $S390X_ID ${{ env.IMAGE_REPO }}:${{ github.ref_name }}-s390x
 
       - name: Create and push multi-arch manifest (version tag)
+        if: github.ref_name != 'oadp-dev'
         run: |
           buildah manifest create ${{ env.IMAGE_REPO }}:${{ github.ref_name }}
           buildah manifest add ${{ env.IMAGE_REPO }}:${{ github.ref_name }} ${{ env.IMAGE_REPO }}:${{ github.ref_name }}-amd64
@@ -92,6 +95,7 @@ jobs:
           buildah manifest push --all ${{ env.IMAGE_REPO }}:${{ github.ref_name }}
 
       - name: Create and push multi-arch manifest (latest tag)
+        if: github.ref_name == 'oadp-dev'
         run: |
           buildah manifest create ${{ env.IMAGE_REPO }}:latest
           buildah manifest add ${{ env.IMAGE_REPO }}:latest ${{ env.IMAGE_REPO }}:${{ github.ref_name }}-amd64

--- a/.github/workflows/quay_binaries_push.yml
+++ b/.github/workflows/quay_binaries_push.yml
@@ -1,10 +1,10 @@
-# Push binaries to Quay.io, when a new release is created
+# Push binaries to Quay.io on pushes to oadp-* branches
 name: Multi-Arch Binary Push to Quay.io
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - 'oadp-*'
   pull_request:
 
 
@@ -58,7 +58,7 @@ jobs:
     name: Create and Push Multi-Arch Manifest
     runs-on: ubuntu-latest
     needs: multi-arch-build
-    if: startsWith(github.ref_name, 'v')
+    if: startsWith(github.ref_name, 'oadp-')
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Changes the workflow trigger from version tags (v*) to oadp-* branches so that images are pushed when PRs merge into oadp-dev or release branches like oadp-1.6. Uses the branch name as the image version tag.

## Why the changes were made

Push to Quay on any push to dev and release branches

## How to test the changes made

Check if it works after a PR goes in or release branch is cut

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated binary distribution workflow to use branch-based triggers (oadp-*) and added branch PR triggers.
  * Adjusted manifest creation logic to run conditionally based on branch name, distinguishing oadp-dev vs version branches.
  * Aligned tag/manifest steps with the new branch-based workflow to ensure correct manifest publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->