### PR TITLE
OADP-7565: Use go-version-file in CI workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
+        go-version-file: 'go.mod'
 
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v9

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,9 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version-file: 'go.mod'
     
     - name: Run tests
       run: go test ./... 


### PR DESCRIPTION
## Summary

- CI workflows updated to use `go-version-file: 'go.mod'` instead of hardcoded versions
  - `lint.yml`: Replace hardcoded `go-version: '1.25'` with `go-version-file: 'go.mod'`
  - `test.yml`: Replace hardcoded `go-version: '1.24'` with `go-version-file: 'go.mod'` and bump `actions/setup-go@v4` → `@v6` (supports toolchain directive)

> [!Note]
> Go toolchain and `golang.org/x/*` CVE bumps were already applied to oadp-1.6 in a prior merge.

Supersedes #165

## Test plan

- [ ] CI passes

> [!Note]
> Responses generated with Claude