### PR TITLE
Set GOTOOLCHAIN=go1.25.7 in konflux.Dockerfile

### DIFF
--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -3,6 +3,7 @@
 # into the build context before this Dockerfile runs.
 
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
+ENV GOTOOLCHAIN=go1.25.7
 
 COPY . /workspace
 WORKDIR /workspace


### PR DESCRIPTION
## Summary
- Override `toolchain go1.25.8` from go.mod with `GOTOOLCHAIN=go1.25.7` in the Konflux builder stage
- go1.25.8 is not yet available in the builder image; this pins to go1.25.7 to unblock builds

## Test plan
- [ ] Konflux build succeeds with go1.25.7