### PR TITLE
Fix ContainerfilesDirect build instead of make targets to catch failures

### DIFF
--- a/Containerfile.download
+++ b/Containerfile.download
@@ -38,7 +38,7 @@ RUN set -e && \
                 -X github.com/vmware-tanzu/velero/pkg/buildinfo.GitTreeState=clean" \
             -o /archives/$output \
             . && \
-        sha256sum /archives/$output > /archives/$output.sha256; \
+        (cd /archives && sha256sum $output > $output.sha256); \
     done && \
     cp LICENSE /archives/LICENSE && \
     rm -rf /root/.cache/go-build /tmp/*

--- a/Containerfile.download
+++ b/Containerfile.download
@@ -40,6 +40,7 @@ RUN set -e && \
             . && \
         (cd /archives && sha256sum $output > $output.sha256); \
     done && \
+    chmod -x /archives/kubectl-oadp_* && \
     cp LICENSE /archives/LICENSE && \
     rm -rf /root/.cache/go-build /tmp/*
 

--- a/Containerfile.download
+++ b/Containerfile.download
@@ -13,21 +13,46 @@ RUN go mod download && go mod verify
 
 COPY . .
 
-RUN make release-binaries && \
+# Version information
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+
+# Build release binaries for all platforms as direct executables
+# with clean names for direct curl/wget download.
+RUN set -e && \
+    mkdir -p /archives && \
+    for platform in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64; do \
+        os=$(echo $platform | cut -d'/' -f1) && \
+        arch=$(echo $platform | cut -d'/' -f2) && \
+        if [ "$os" = "windows" ]; then \
+            output="kubectl-oadp_${os}_${arch}.exe"; \
+        else \
+            output="kubectl-oadp_${os}_${arch}"; \
+        fi && \
+        echo "Building $output..." && \
+        CGO_ENABLED=0 GOOS=$os GOARCH=$arch \
+            go build -trimpath \
+            -ldflags="-s -w \
+                -X github.com/vmware-tanzu/velero/pkg/buildinfo.Version=${VERSION} \
+                -X github.com/vmware-tanzu/velero/pkg/buildinfo.GitSHA=${GIT_COMMIT} \
+                -X github.com/vmware-tanzu/velero/pkg/buildinfo.GitTreeState=clean" \
+            -o /archives/$output \
+            . && \
+        sha256sum /archives/$output > /archives/$output.sha256; \
+    done && \
+    cp LICENSE /archives/LICENSE && \
     rm -rf /root/.cache/go-build /tmp/*
 
 # Build the download server for the TARGET platform (the arch this container will run on)
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o download-server ./cmd/downloads/ && \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -trimpath -o /usr/local/bin/download-server ./cmd/downloads/ && \
     go clean -cache -modcache -testcache && \
     rm -rf /root/.cache/go-build /go/pkg
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
-# Copy binaries, checksums, and LICENSE
-COPY --from=builder /app/release-binaries /archives
-
-# Copy the download server
-COPY --from=builder /app/download-server /usr/local/bin/download-server
+COPY --from=builder /archives /archives
+COPY --from=builder /usr/local/bin/download-server /usr/local/bin/download-server
 
 EXPOSE 8080
 

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -32,7 +32,7 @@ RUN set -e && \
                 -X github.com/vmware-tanzu/velero/pkg/buildinfo.GitTreeState=clean" \
             -o /archives/$output \
             . && \
-        sha256sum /archives/$output > /archives/$output.sha256; \
+        (cd /archives && sha256sum $output > $output.sha256); \
     done && \
     cp LICENSE /archives/LICENSE && \
     rm -rf /root/.cache/go-build /tmp/*

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -34,6 +34,7 @@ RUN set -e && \
             . && \
         (cd /archives && sha256sum $output > $output.sha256); \
     done && \
+    chmod -x /archives/kubectl-oadp_* && \
     cp LICENSE /archives/LICENSE && \
     rm -rf /root/.cache/go-build /tmp/*
 

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -7,14 +7,39 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25
 COPY . /workspace
 WORKDIR /workspace
 
+# Version information
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+
 # Build release binaries for all platforms (CGO_ENABLED=0 for cross-platform
 # portability — CLI binaries run on user machines outside the FIPS boundary)
-RUN make release-binaries && \
+RUN set -e && \
+    mkdir -p /archives && \
+    for platform in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64; do \
+        os=$(echo $platform | cut -d'/' -f1) && \
+        arch=$(echo $platform | cut -d'/' -f2) && \
+        if [ "$os" = "windows" ]; then \
+            output="kubectl-oadp_${os}_${arch}.exe"; \
+        else \
+            output="kubectl-oadp_${os}_${arch}"; \
+        fi && \
+        echo "Building $output..." && \
+        CGO_ENABLED=0 GOOS=$os GOARCH=$arch \
+            go build -trimpath -mod=mod \
+            -ldflags="-s -w \
+                -X github.com/vmware-tanzu/velero/pkg/buildinfo.Version=${VERSION} \
+                -X github.com/vmware-tanzu/velero/pkg/buildinfo.GitSHA=${GIT_COMMIT} \
+                -X github.com/vmware-tanzu/velero/pkg/buildinfo.GitTreeState=clean" \
+            -o /archives/$output \
+            . && \
+        sha256sum /archives/$output > /archives/$output.sha256; \
+    done && \
+    cp LICENSE /archives/LICENSE && \
     rm -rf /root/.cache/go-build /tmp/*
 
 # Build the download server (FIPS-compliant, runs in-cluster on RHEL)
 RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GOOS=linux \
-    go build -mod=readonly -a -tags strictfipsruntime \
+    go build -trimpath -mod=mod -a -tags strictfipsruntime \
     -o /workspace/bin/download-server ./cmd/downloads/ && \
     go clean -cache -modcache -testcache && \
     rm -rf /root/.cache/go-build /go/pkg
@@ -23,7 +48,7 @@ FROM registry.redhat.io/ubi9/ubi:latest
 
 RUN dnf -y install openssl && dnf -y reinstall tzdata && dnf clean all
 
-COPY --from=builder /workspace/release-binaries /archives
+COPY --from=builder /archives /archives
 COPY --from=builder /workspace/bin/download-server /usr/local/bin/download-server
 COPY LICENSE /licenses/
 


### PR DESCRIPTION
## Why the changes were made

konflux.Dockerfile successfully builds but the oadp-cli binaries are absent: make target silently fails

## How to test the changes made

konflux.Dockerfile build should succeed without issue 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Restructured build to explicitly cross-compile platform-specific executables for Linux, macOS, and Windows (amd64/arm64), embedding version and commit metadata into each binary.
  * Produces per-binary checksums, includes license alongside artifacts, and adjusted packaging to collect all produced archives for the final image.
  * Updated the download-server build output handling and build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->