### PR TITLE
Default namespace to openshift-adp instead of velero

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -382,12 +382,17 @@ func NewVeleroRootCommand(baseName string) *cobra.Command {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "WARNING: Error reading config file: %v\n", err)
 	}
+	if config == nil {
+		config = clientcmd.VeleroConfig{}
+	}
 
 	// When nonadmin mode is enabled, remove the namespace override so the
 	// factory uses the current kubeconfig context namespace instead of an
 	// admin namespace like openshift-adp.
 	if isNonadminEnabled(config) {
 		delete(config, clientcmd.ConfigKeyNamespace)
+	} else if config.Namespace() == "" {
+		config[clientcmd.ConfigKeyNamespace] = "openshift-adp"
 	}
 
 	// Declare cmdFeatures and cmdColorzied here so we can access them in the PreRun hooks

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -738,6 +739,44 @@ func TestReplaceVeleroWithOADP_OutputWrapperExclusions(t *testing.T) {
 			t.Errorf("Excluded command output should NOT be modified, got: %s", output)
 		}
 	})
+}
+
+// TestDefaultNamespaceIsOpenShiftADP verifies that when no config file or
+// VELERO_NAMESPACE env var is present, the CLI defaults to openshift-adp.
+func TestDefaultNamespaceIsOpenShiftADP(t *testing.T) {
+	binaryPath := testutil.BuildCLIBinary(t)
+
+	// Use a temp HOME so no ~/.config/velero/config.json exists
+	tempHome := t.TempDir()
+
+	ctx, cancel := context.WithTimeout(context.Background(), testutil.TestTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binaryPath, "--help")
+	cmd.Env = append(os.Environ(),
+		"HOME="+tempHome,
+	)
+	// Remove VELERO_NAMESPACE if set
+	filtered := cmd.Env[:0]
+	for _, e := range cmd.Env {
+		if !strings.HasPrefix(e, "VELERO_NAMESPACE=") {
+			filtered = append(filtered, e)
+		}
+	}
+	cmd.Env = filtered
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("command failed: %v\n%s", err, string(out))
+	}
+
+	output := string(out)
+	if !strings.Contains(output, `(default "openshift-adp")`) {
+		t.Errorf("Expected namespace default to be openshift-adp, got:\n%s", output)
+	}
+	if strings.Contains(output, `(default "velero")`) {
+		t.Errorf("Namespace should not default to velero, got:\n%s", output)
+	}
 }
 
 // TestApplyTimeoutToConfig_DialerTimeout tests that the custom dialer respects the timeout

--- a/cmd/shared/factories.go
+++ b/cmd/shared/factories.go
@@ -22,8 +22,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/vmware-tanzu/velero/pkg/client"
 )
 
 // ClientConfig represents the structure of the Velero client configuration file
@@ -57,33 +55,6 @@ func (c *ClientConfig) GetDefaultNABSL() string {
 		return ""
 	}
 	return c.DefaultNABSL
-}
-
-// CreateVeleroFactory creates a client factory for Velero operations (admin-scoped)
-// that uses the client configuration to determine the namespace.
-// Priority order:
-// 1. Velero client config (~/.config/velero/config.json)
-// 2. Kubeconfig context namespace
-// 3. Velero default (usually "velero")
-func CreateVeleroFactory() client.Factory {
-	cfg := client.VeleroConfig{}
-
-	// Try to read client config to get configured namespace
-	if clientConfig, err := ReadVeleroClientConfig(); err == nil {
-		if clientConfig.Namespace != "" {
-			cfg[client.ConfigKeyNamespace] = clientConfig.Namespace
-		}
-	}
-
-	return client.NewFactory("oadp-velero-cli", cfg)
-}
-
-// CreateNonAdminFactory creates a client factory for NonAdminBackup operations
-// that uses the current kubeconfig context namespace instead of hardcoded openshift-adp
-func CreateNonAdminFactory() client.Factory {
-	// Don't set a default namespace, let it use the kubeconfig context
-	cfg := client.VeleroConfig{}
-	return client.NewFactory("oadp-velero-cli", cfg)
 }
 
 // ReadVeleroClientConfig reads the Velero client configuration from ~/.config/velero/config.json


### PR DESCRIPTION
## Why the changes were made

Fixes [OADP-6555](https://redhat.atlassian.net/browse/OADP-6555) — the CLI defaults to the `velero` namespace when no `VELERO_NAMESPACE` env var or `~/.config/velero/config.json` exists. This is because the upstream Velero library hardcodes `"velero"` as `DefaultNamespace`. For OADP, the correct default is `openshift-adp`.

The fix sets `openshift-adp` as the namespace in the root command config when no namespace is otherwise configured. Users who have run `oc oadp setup` or set `VELERO_NAMESPACE` are unaffected.

Also removes dead code: `CreateVeleroFactory` and `CreateNonAdminFactory` in `factories.go` were never called.

## How to test the changes made

- Build the CLI and run `oc oadp --help` without a config file or `VELERO_NAMESPACE` env var
- Verify the namespace flag shows `(default "openshift-adp")` instead of `(default "velero")`
- Run the new test: `go test ./cmd/ -run TestDefaultNamespaceIsOpenShiftADP -v`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The CLI now defaults the namespace to openshift-adp when no namespace is configured, ensuring consistent behavior across modes.

* **Tests**
  * Added an integration-style test to verify the new default namespace appears in help output when no config or environment override is present.

* **Refactor**
  * Removed obsolete factory constructors to simplify internal client setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->