### PR TITLE
Rename VERSION to OADP_VERSION in konflux.Dockerfile

### DIFF
--- a/Containerfile.download
+++ b/Containerfile.download
@@ -13,8 +13,8 @@ RUN go mod download && go mod verify
 
 COPY . .
 
-# Version information
-ARG VERSION=dev
+# Version information (OADP_VERSION avoids collision with Konflux-injected VERSION)
+ARG OADP_VERSION=dev
 ARG GIT_COMMIT=unknown
 
 # Build release binaries for all platforms as direct executables
@@ -33,7 +33,7 @@ RUN set -e && \
         CGO_ENABLED=0 GOOS=$os GOARCH=$arch \
             go build -trimpath \
             -ldflags="-s -w \
-                -X github.com/vmware-tanzu/velero/pkg/buildinfo.Version=${VERSION} \
+                -X github.com/vmware-tanzu/velero/pkg/buildinfo.Version=${OADP_VERSION} \
                 -X github.com/vmware-tanzu/velero/pkg/buildinfo.GitSHA=${GIT_COMMIT} \
                 -X github.com/vmware-tanzu/velero/pkg/buildinfo.GitTreeState=clean" \
             -o /archives/$output \

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -7,8 +7,8 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25
 COPY . /workspace
 WORKDIR /workspace
 
-# Version information
-ARG VERSION=dev
+# Version information (OADP_VERSION avoids collision with Konflux-injected VERSION)
+ARG OADP_VERSION=dev
 ARG GIT_COMMIT=unknown
 
 # Build release binaries for all platforms (CGO_ENABLED=0 for cross-platform
@@ -27,7 +27,7 @@ RUN set -e && \
         CGO_ENABLED=0 GOOS=$os GOARCH=$arch \
             go build -trimpath -mod=mod \
             -ldflags="-s -w \
-                -X github.com/vmware-tanzu/velero/pkg/buildinfo.Version=${VERSION} \
+                -X github.com/vmware-tanzu/velero/pkg/buildinfo.Version=${OADP_VERSION} \
                 -X github.com/vmware-tanzu/velero/pkg/buildinfo.GitSHA=${GIT_COMMIT} \
                 -X github.com/vmware-tanzu/velero/pkg/buildinfo.GitTreeState=clean" \
             -o /archives/$output \


### PR DESCRIPTION
## Summary
- Konflux auto-injects `VERSION` as the Go toolchain version from the builder image (e.g. `1.25`), which collides with our `VERSION` build arg used for `buildinfo.Version` ldflags
- This causes `oc oadp version` to report `Version: 1.25` (the Go version) instead of the actual OADP version
- Renames the build arg to `OADP_VERSION` to avoid the collision
- Release branches should hardcode the value (e.g. `OADP_VERSION=v1.6.0`) after cherry-picking

## Test plan
- [ ] Verify Konflux build produces binary with `Version: dev` (not `1.25`)
- [ ] After cherry-pick to release branch with hardcoded version, verify `oc oadp version` shows correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to resolve variable naming conflicts during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->