### PR TITLE
Use ART-injected env vars for version in Konflux builds

### DIFF
--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -7,13 +7,14 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25
 COPY . /workspace
 WORKDIR /workspace
 
-# Version information (OADP_VERSION avoids collision with Konflux-injected VERSION)
-ARG OADP_VERSION=dev
-ARG GIT_COMMIT=unknown
-
 # Build release binaries for all platforms (CGO_ENABLED=0 for cross-platform
 # portability — CLI binaries run on user machines outside the FIPS boundary)
+#
+# Version info: prefer ART-injected BUILD_VERSION/SOURCE_GIT_COMMIT env vars
+# (set by doozer in Konflux builds), fall back to defaults for local builds.
 RUN set -e && \
+    OADP_VERSION="${BUILD_VERSION:-dev}" && \
+    OADP_GIT_COMMIT="${SOURCE_GIT_COMMIT:-unknown}" && \
     mkdir -p /archives && \
     for platform in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64; do \
         os=$(echo $platform | cut -d'/' -f1) && \
@@ -23,12 +24,12 @@ RUN set -e && \
         else \
             output="kubectl-oadp_${os}_${arch}"; \
         fi && \
-        echo "Building $output..." && \
+        echo "Building $output (version=${OADP_VERSION})..." && \
         CGO_ENABLED=0 GOOS=$os GOARCH=$arch \
             go build -trimpath -mod=mod \
             -ldflags="-s -w \
                 -X github.com/vmware-tanzu/velero/pkg/buildinfo.Version=${OADP_VERSION} \
-                -X github.com/vmware-tanzu/velero/pkg/buildinfo.GitSHA=${GIT_COMMIT} \
+                -X github.com/vmware-tanzu/velero/pkg/buildinfo.GitSHA=${OADP_GIT_COMMIT} \
                 -X github.com/vmware-tanzu/velero/pkg/buildinfo.GitTreeState=clean" \
             -o /archives/$output \
             . && \


### PR DESCRIPTION
## Summary
- ART/doozer injects `BUILD_VERSION`, `SOURCE_GIT_COMMIT`, and other env vars into the builder stage before our `RUN` step executes 
- https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/art-oadp-tenant/applications/oadp-1-6/taskruns/oadp-1-6-oadp-cli-binaries-854k5-build-images-0/logs lines 841 -> 950
- https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/art-oadp-tenant/applications/oadp-1-6/taskruns/oadp-1-6-oadp-cli-binaries-854k5-build-images-0/logs#L964
- Previously we used `ARG VERSION=dev` which collided with the Konflux-injected `VERSION` (the Go toolchain version from the builder image), causing `oc oadp version` to report `Version: 1.25` instead of the OADP version
- Now uses `BUILD_VERSION` and `SOURCE_GIT_COMMIT` directly from the ART-injected env vars
- Falls back to `dev`/`unknown` for local builds where ART env vars are not present

### ART env vars used
| Variable | Source | Purpose |
|----------|--------|---------|
| `BUILD_VERSION` | doozer, derived from group config | OADP version (e.g. `1.6.0`) |
| `SOURCE_GIT_COMMIT` | doozer, from source git | Full git SHA for `buildinfo.GitSHA` |

## Test plan
- [ ] Verify next Konflux build produces binary with correct version (`oc oadp version` shows `1.6.0`, not `1.25`)
- [ ] Verify local `podman build -f konflux.Dockerfile .` still works (falls back to `dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build process to derive version information from environment variables with fallback defaults, improving CI/CD integration for platform-specific builds and enhancing version tracking in build logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->