### PR TITLE
Hardcode VERSION to oadp-1.6 for standardised version reporting

### DIFF
--- a/Containerfile.download
+++ b/Containerfile.download
@@ -14,7 +14,7 @@ RUN go mod download && go mod verify
 COPY . .
 
 # Version information (OADP_VERSION avoids collision with Konflux-injected VERSION)
-ARG OADP_VERSION=dev
+ARG OADP_VERSION=oadp-1.6
 ARG GIT_COMMIT=unknown
 
 # Build release binaries for all platforms as direct executables

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Variables
 BINARY_NAME = kubectl-oadp
 INSTALL_PATH ?= $(HOME)/.local/bin
-VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+VERSION ?= oadp-1.6
 VELERO_NAMESPACE ?= openshift-adp
 ASSUME_DEFAULT ?= false
 


### PR DESCRIPTION
## Why the changes were made

Previously, `VERSION` was derived from `git describe --tags --always --dirty`,
which produced opaque commit hashes as the version string. This made
`oc oadp version` output meaningless to users.

This PR hardcodes the version to `oadp-1.6` in both the Makefile and
Containerfile.download so that users get a clear, recognisable version
string that maps to the branch the binary was built from. The git SHA
is still injected separately for exact commit identification.

## How to test the changes made

1. Build locally via `make build` and run `./kubectl-oadp version` —
   client version should show `oadp-1.6`.
2. Build via `make install` and run `oc oadp version` — same result.
3. Build the container image with `podman build -f Containerfile.download .`
   and verify the embedded binaries report `oadp-1.6`.