### PR TITLE
OADP-7955: Hides --namespace flag from nonadmin commands

### DIFF
--- a/cmd/non-admin/namespace.go
+++ b/cmd/non-admin/namespace.go
@@ -25,7 +25,10 @@ import (
 // ConfigureNamespaceBehavior hides the inherited --namespace flag from nonadmin
 // help output and rejects runtime use of -n/--namespace. Nonadmin operations are
 // scoped to the user's current context namespace for security.
-func ConfigureNamespaceBehavior(cmd *cobra.Command) {
+func ConfigureNamespaceBehavior(
+	cmd *cobra.Command,
+	runGlobalSetup func(cmd *cobra.Command, args []string),
+) {
 	hideNamespaceFlagFromCommand(cmd)
 
 	existingPersistentPreRunE := cmd.PersistentPreRunE
@@ -34,6 +37,9 @@ func ConfigureNamespaceBehavior(cmd *cobra.Command) {
 	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
 		if c.Flags().Changed("namespace") {
 			return fmt.Errorf("-n/--namespace is not supported for nonadmin commands; namespace is determined by your current context")
+		}
+		if runGlobalSetup != nil {
+			runGlobalSetup(c, args)
 		}
 		if existingPersistentPreRunE != nil {
 			return existingPersistentPreRunE(c, args)

--- a/cmd/non-admin/namespace.go
+++ b/cmd/non-admin/namespace.go
@@ -28,9 +28,18 @@ import (
 func ConfigureNamespaceBehavior(cmd *cobra.Command) {
 	hideNamespaceFlagFromCommand(cmd)
 
+	existingPersistentPreRunE := cmd.PersistentPreRunE
+	existingPersistentPreRun := cmd.PersistentPreRun
+
 	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
 		if c.Flags().Changed("namespace") {
 			return fmt.Errorf("-n/--namespace is not supported for nonadmin commands; namespace is determined by your current context")
+		}
+		if existingPersistentPreRunE != nil {
+			return existingPersistentPreRunE(c, args)
+		}
+		if existingPersistentPreRun != nil {
+			existingPersistentPreRun(c, args)
 		}
 		return nil
 	}
@@ -39,15 +48,30 @@ func ConfigureNamespaceBehavior(cmd *cobra.Command) {
 func hideNamespaceFlagFromCommand(cmd *cobra.Command) {
 	originalHelpFunc := cmd.HelpFunc()
 	cmd.SetHelpFunc(func(c *cobra.Command, args []string) {
-		if flag := c.InheritedFlags().Lookup("namespace"); flag != nil {
-			originalHidden := flag.Hidden
-			flag.Hidden = true
-			defer func() { flag.Hidden = originalHidden }()
-		}
-		originalHelpFunc(c, args)
+		withHiddenNamespaceFlag(c, func() {
+			originalHelpFunc(c, args)
+		})
+	})
+
+	originalUsageFunc := cmd.UsageFunc()
+	cmd.SetUsageFunc(func(c *cobra.Command) error {
+		var err error
+		withHiddenNamespaceFlag(c, func() {
+			err = originalUsageFunc(c)
+		})
+		return err
 	})
 
 	for _, subCmd := range cmd.Commands() {
 		hideNamespaceFlagFromCommand(subCmd)
 	}
+}
+
+func withHiddenNamespaceFlag(cmd *cobra.Command, fn func()) {
+	if flag := cmd.InheritedFlags().Lookup("namespace"); flag != nil {
+		originalHidden := flag.Hidden
+		flag.Hidden = true
+		defer func() { flag.Hidden = originalHidden }()
+	}
+	fn()
 }

--- a/cmd/non-admin/namespace.go
+++ b/cmd/non-admin/namespace.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2025 The OADP CLI Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nonadmin
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// ConfigureNamespaceBehavior hides the inherited --namespace flag from nonadmin
+// help output and rejects runtime use of -n/--namespace. Nonadmin operations are
+// scoped to the user's current context namespace for security.
+func ConfigureNamespaceBehavior(cmd *cobra.Command) {
+	hideNamespaceFlagFromCommand(cmd)
+
+	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
+		if c.Flags().Changed("namespace") {
+			return fmt.Errorf("-n/--namespace is not supported for nonadmin commands; namespace is determined by your current context")
+		}
+		return nil
+	}
+}
+
+func hideNamespaceFlagFromCommand(cmd *cobra.Command) {
+	originalHelpFunc := cmd.HelpFunc()
+	cmd.SetHelpFunc(func(c *cobra.Command, args []string) {
+		if flag := c.InheritedFlags().Lookup("namespace"); flag != nil {
+			originalHidden := flag.Hidden
+			flag.Hidden = true
+			defer func() { flag.Hidden = originalHidden }()
+		}
+		originalHelpFunc(c, args)
+	})
+
+	for _, subCmd := range cmd.Commands() {
+		hideNamespaceFlagFromCommand(subCmd)
+	}
+}

--- a/cmd/non-admin/namespace_test.go
+++ b/cmd/non-admin/namespace_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/migtools/oadp-cli/internal/testutil"
+	"github.com/spf13/cobra"
 )
 
 func TestNonAdminNamespaceFlagBehavior(t *testing.T) {
@@ -32,6 +33,23 @@ func TestNonAdminNamespaceFlagBehavior(t *testing.T) {
 		output, _ := testutil.RunCommand(t, binaryPath, "nonadmin", "backup", "get", "--help")
 		if strings.Contains(output, "-n, --namespace") || strings.Contains(output, "--namespace string") {
 			t.Errorf("Expected help output not to contain the namespace flag\nFull output:\n%s", output)
+		}
+	})
+
+	t.Run("calls global persistent setup", func(t *testing.T) {
+		var globalSetupCalled bool
+		globalSetup := func(cmd *cobra.Command, args []string) {
+			globalSetupCalled = true
+		}
+
+		cmd := &cobra.Command{Use: "nonadmin"}
+		ConfigureNamespaceBehavior(cmd, globalSetup)
+
+		if err := cmd.PersistentPreRunE(cmd, []string{}); err != nil {
+			t.Fatalf("PersistentPreRunE returned error: %v", err)
+		}
+		if !globalSetupCalled {
+			t.Error("Expected global persistent setup to run for nonadmin command")
 		}
 	})
 

--- a/cmd/non-admin/namespace_test.go
+++ b/cmd/non-admin/namespace_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2025 The OADP CLI Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nonadmin
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/migtools/oadp-cli/internal/testutil"
+)
+
+func TestNonAdminNamespaceFlagBehavior(t *testing.T) {
+	binaryPath := testutil.BuildCLIBinary(t)
+
+	t.Run("help hides namespace flag", func(t *testing.T) {
+		output, _ := testutil.RunCommand(t, binaryPath, "nonadmin", "backup", "get", "--help")
+		if strings.Contains(output, "--namespace") {
+			t.Errorf("Expected help output not to contain --namespace\nFull output:\n%s", output)
+		}
+	})
+
+	t.Run("rejects namespace flag at runtime", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), testutil.TestTimeout)
+		defer cancel()
+
+		output, err := exec.CommandContext(ctx, binaryPath, "nonadmin", "backup", "get", "-n", "other-namespace").CombinedOutput()
+		if err == nil {
+			t.Fatalf("Expected error when -n/--namespace is provided, got output:\n%s", string(output))
+		}
+		expected := "-n/--namespace is not supported for nonadmin commands; namespace is determined by your current context"
+		if !strings.Contains(string(output), expected) {
+			t.Errorf("Expected output to contain %q, got:\n%s", expected, string(output))
+		}
+	})
+}

--- a/cmd/non-admin/namespace_test.go
+++ b/cmd/non-admin/namespace_test.go
@@ -30,8 +30,8 @@ func TestNonAdminNamespaceFlagBehavior(t *testing.T) {
 
 	t.Run("help hides namespace flag", func(t *testing.T) {
 		output, _ := testutil.RunCommand(t, binaryPath, "nonadmin", "backup", "get", "--help")
-		if strings.Contains(output, "--namespace") {
-			t.Errorf("Expected help output not to contain --namespace\nFull output:\n%s", output)
+		if strings.Contains(output, "-n, --namespace") || strings.Contains(output, "--namespace string") {
+			t.Errorf("Expected help output not to contain the namespace flag\nFull output:\n%s", output)
 		}
 	})
 

--- a/cmd/non-admin/nonadmin.go
+++ b/cmd/non-admin/nonadmin.go
@@ -50,5 +50,7 @@ func NewNonAdminCommand(f client.Factory) *cobra.Command {
 	c.AddCommand(verbs.NewDescribeCommand(f))
 	c.AddCommand(verbs.NewLogsCommand(f))
 
+	ConfigureNamespaceBehavior(c)
+
 	return c
 }

--- a/cmd/non-admin/nonadmin.go
+++ b/cmd/non-admin/nonadmin.go
@@ -50,7 +50,5 @@ func NewNonAdminCommand(f client.Factory) *cobra.Command {
 	c.AddCommand(verbs.NewDescribeCommand(f))
 	c.AddCommand(verbs.NewLogsCommand(f))
 
-	ConfigureNamespaceBehavior(c)
-
 	return c
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -458,6 +458,14 @@ func NewVeleroRootCommand(baseName string) *cobra.Command {
 	// NonAdmin operations are namespace-scoped to the user's current context for security
 	hideNamespaceFlagFromCommand(nonadminCmd)
 
+	// Reject --namespace flag if used with nonadmin commands
+	nonadminCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		if cmd.Flags().Changed("namespace") {
+			return fmt.Errorf("-n/--namespace is not supported for nonadmin commands; namespace is determined by your current context")
+		}
+		return nil
+	}
+
 	// Must-gather command - diagnostic tool
 	c.AddCommand(mustgather.NewMustGatherCommand(f))
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -515,8 +515,9 @@ func hideNamespaceFlagFromCommand(cmd *cobra.Command) {
 	cmd.SetHelpFunc(func(c *cobra.Command, args []string) {
 		// Temporarily hide the namespace flag for this help output
 		if flag := c.InheritedFlags().Lookup("namespace"); flag != nil {
+			originalHidden := flag.Hidden
 			flag.Hidden = true
-			defer func() { flag.Hidden = false }()
+			defer func() { flag.Hidden = originalHidden }()
 		}
 		originalHelpFunc(c, args)
 	})

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -509,14 +509,19 @@ func NewVeleroRootCommand(baseName string) *cobra.Command {
 
 // hideNamespaceFlagFromCommand recursively hides the --namespace flag from a command and all its subcommands
 func hideNamespaceFlagFromCommand(cmd *cobra.Command) {
-	// Hide from both local and inherited (persistent) flags
-	if flag := cmd.LocalFlags().Lookup("namespace"); flag != nil {
-		flag.Hidden = true
-	}
-	if flag := cmd.InheritedFlags().Lookup("namespace"); flag != nil {
-		flag.Hidden = true
-	}
-	// Recursively hide from all subcommands
+	// For each command, we need to hide the inherited namespace flag in its help output
+	// We do this by overriding the HelpFunc to filter out the namespace flag
+	originalHelpFunc := cmd.HelpFunc()
+	cmd.SetHelpFunc(func(c *cobra.Command, args []string) {
+		// Temporarily hide the namespace flag for this help output
+		if flag := c.InheritedFlags().Lookup("namespace"); flag != nil {
+			flag.Hidden = true
+			defer func() { flag.Hidden = false }()
+		}
+		originalHelpFunc(c, args)
+	})
+
+	// Recursively apply to all subcommands
 	for _, subCmd := range cmd.Commands() {
 		hideNamespaceFlagFromCommand(subCmd)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -517,9 +517,11 @@ func NewVeleroRootCommand(baseName string) *cobra.Command {
 
 // hideNamespaceFlagFromCommand recursively hides the --namespace flag from a command and all its subcommands
 func hideNamespaceFlagFromCommand(cmd *cobra.Command) {
-	// For each command, we need to hide the inherited namespace flag in its help output
-	// We do this by overriding the HelpFunc to filter out the namespace flag
-	originalHelpFunc := cmd.HelpFunc()
+	// Get the default Cobra help function before we start modifying anything
+	// This avoids infinite recursion if HelpFunc gets called multiple times
+	defaultHelpFunc := cmd.HelpFunc()
+
+	// Set custom help function that hides namespace flag
 	cmd.SetHelpFunc(func(c *cobra.Command, args []string) {
 		// Temporarily hide the namespace flag for this help output
 		if flag := c.InheritedFlags().Lookup("namespace"); flag != nil {
@@ -527,7 +529,8 @@ func hideNamespaceFlagFromCommand(cmd *cobra.Command) {
 			flag.Hidden = true
 			defer func() { flag.Hidden = originalHidden }()
 		}
-		originalHelpFunc(c, args)
+		// Call the default help function, not cmd.HelpFunc() which would cause recursion
+		defaultHelpFunc(c, args)
 	})
 
 	// Recursively apply to all subcommands

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -451,7 +451,12 @@ func NewVeleroRootCommand(baseName string) *cobra.Command {
 	c.AddCommand(nabsl.NewNABSLRequestCommand(f))
 
 	// Custom subcommands - use NonAdmin factory
-	c.AddCommand(nonadmin.NewNonAdminCommand(f))
+	nonadminCmd := nonadmin.NewNonAdminCommand(f)
+	c.AddCommand(nonadminCmd)
+
+	// Hide --namespace flag from nonadmin commands
+	// NonAdmin operations are namespace-scoped to the user's current context for security
+	hideNamespaceFlagFromCommand(nonadminCmd)
 
 	// Must-gather command - diagnostic tool
 	c.AddCommand(mustgather.NewMustGatherCommand(f))
@@ -500,4 +505,19 @@ func NewVeleroRootCommand(baseName string) *cobra.Command {
 	klog.InitFlags(flag.CommandLine)
 	c.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	return c
+}
+
+// hideNamespaceFlagFromCommand recursively hides the --namespace flag from a command and all its subcommands
+func hideNamespaceFlagFromCommand(cmd *cobra.Command) {
+	// Hide from both local and inherited (persistent) flags
+	if flag := cmd.LocalFlags().Lookup("namespace"); flag != nil {
+		flag.Hidden = true
+	}
+	if flag := cmd.InheritedFlags().Lookup("namespace"); flag != nil {
+		flag.Hidden = true
+	}
+	// Recursively hide from all subcommands
+	for _, subCmd := range cmd.Commands() {
+		hideNamespaceFlagFromCommand(subCmd)
+	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -375,6 +375,24 @@ func isNonadminEnabled(config clientcmd.VeleroConfig) bool {
 	}
 }
 
+func configureGlobalCommandBehavior(
+	config clientcmd.VeleroConfig,
+	cmdFeatures veleroflag.StringArray,
+	cmdColorized veleroflag.OptionalBool,
+) func(cmd *cobra.Command, args []string) {
+	return func(cmd *cobra.Command, args []string) {
+		features.Enable(config.Features()...)
+		features.Enable(cmdFeatures...)
+
+		switch {
+		case cmdColorized.Value != nil:
+			color.NoColor = !*cmdColorized.Value
+		default:
+			color.NoColor = !config.Colorized()
+		}
+	}
+}
+
 // NewVeleroRootCommand returns a root command with all Velero CLI subcommands attached.
 func NewVeleroRootCommand(baseName string) *cobra.Command {
 
@@ -400,6 +418,8 @@ func NewVeleroRootCommand(baseName string) *cobra.Command {
 	var cmdFeatures veleroflag.StringArray
 	var cmdColorzied veleroflag.OptionalBool
 
+	globalPreRun := configureGlobalCommandBehavior(config, cmdFeatures, cmdColorzied)
+
 	c := &cobra.Command{
 		Use:   baseName,
 		Short: "OADP CLI commands",
@@ -407,17 +427,7 @@ func NewVeleroRootCommand(baseName string) *cobra.Command {
 			// Default action when no subcommand is provided
 			fmt.Println("Welcome to the OADP CLI! Use --help to see available commands.")
 		},
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			features.Enable(config.Features()...)
-			features.Enable(cmdFeatures...)
-
-			switch {
-			case cmdColorzied.Value != nil:
-				color.NoColor = !*cmdColorzied.Value
-			default:
-				color.NoColor = !config.Colorized()
-			}
-		},
+		PersistentPreRun: globalPreRun,
 	}
 
 	// Create Velero client factory for regular Velero commands
@@ -451,7 +461,9 @@ func NewVeleroRootCommand(baseName string) *cobra.Command {
 	c.AddCommand(nabsl.NewNABSLRequestCommand(f))
 
 	// Custom subcommands - use NonAdmin factory
-	c.AddCommand(nonadmin.NewNonAdminCommand(f))
+	nonadminCmd := nonadmin.NewNonAdminCommand(f)
+	nonadmin.ConfigureNamespaceBehavior(nonadminCmd, globalPreRun)
+	c.AddCommand(nonadminCmd)
 
 	// Must-gather command - diagnostic tool
 	c.AddCommand(mustgather.NewMustGatherCommand(f))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -451,20 +451,7 @@ func NewVeleroRootCommand(baseName string) *cobra.Command {
 	c.AddCommand(nabsl.NewNABSLRequestCommand(f))
 
 	// Custom subcommands - use NonAdmin factory
-	nonadminCmd := nonadmin.NewNonAdminCommand(f)
-	c.AddCommand(nonadminCmd)
-
-	// Hide --namespace flag from nonadmin commands
-	// NonAdmin operations are namespace-scoped to the user's current context for security
-	hideNamespaceFlagFromCommand(nonadminCmd)
-
-	// Reject --namespace flag if used with nonadmin commands
-	nonadminCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		if cmd.Flags().Changed("namespace") {
-			return fmt.Errorf("-n/--namespace is not supported for nonadmin commands; namespace is determined by your current context")
-		}
-		return nil
-	}
+	c.AddCommand(nonadmin.NewNonAdminCommand(f))
 
 	// Must-gather command - diagnostic tool
 	c.AddCommand(mustgather.NewMustGatherCommand(f))
@@ -513,16 +500,4 @@ func NewVeleroRootCommand(baseName string) *cobra.Command {
 	klog.InitFlags(flag.CommandLine)
 	c.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	return c
-}
-
-// hideNamespaceFlagFromCommand recursively hides the --namespace flag from a command and all its subcommands
-func hideNamespaceFlagFromCommand(cmd *cobra.Command) {
-	// Mark the command so we can identify it needs the namespace flag hidden
-	// We'll handle this in a PersistentPreRun hook to avoid modifying the shared flag object
-	cmd.Annotations = map[string]string{"hide-namespace-flag": "true"}
-
-	// Recursively apply to all subcommands
-	for _, subCmd := range cmd.Commands() {
-		hideNamespaceFlagFromCommand(subCmd)
-	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -517,21 +517,9 @@ func NewVeleroRootCommand(baseName string) *cobra.Command {
 
 // hideNamespaceFlagFromCommand recursively hides the --namespace flag from a command and all its subcommands
 func hideNamespaceFlagFromCommand(cmd *cobra.Command) {
-	// Get the default Cobra help function before we start modifying anything
-	// This avoids infinite recursion if HelpFunc gets called multiple times
-	defaultHelpFunc := cmd.HelpFunc()
-
-	// Set custom help function that hides namespace flag
-	cmd.SetHelpFunc(func(c *cobra.Command, args []string) {
-		// Temporarily hide the namespace flag for this help output
-		if flag := c.InheritedFlags().Lookup("namespace"); flag != nil {
-			originalHidden := flag.Hidden
-			flag.Hidden = true
-			defer func() { flag.Hidden = originalHidden }()
-		}
-		// Call the default help function, not cmd.HelpFunc() which would cause recursion
-		defaultHelpFunc(c, args)
-	})
+	// Mark the command so we can identify it needs the namespace flag hidden
+	// We'll handle this in a PersistentPreRun hook to avoid modifying the shared flag object
+	cmd.Annotations = map[string]string{"hide-namespace-flag": "true"}
 
 	// Recursively apply to all subcommands
 	for _, subCmd := range cmd.Commands() {


### PR DESCRIPTION
## Why the changes were made

The `--namespace` flag was appearing in the help section for all nonadmin commands, but was silently ignored. If the user tried to use the `-n, --namespace` under a NAB, the flag was ignored. The user should not be able to see flags that they cannot use in that context which is why I chose to hide the flag from the user.

## How to test the changes made

  **Verify the namespace flag is hidden from nonadmin commands:**
  ```bash
  # Check nonadmin backup commands - should NOT show -n, --namespace flag
  oc oadp nonadmin backup get --help

  # Check nonadmin restore commands - should NOT show -n, --namespace flag
  oc oadp nonadmin restore get --help

  Before this fix:
  The Global Flags section showed:
  -n, --namespace string    The namespace in which Velero should operate (default "openshift-adp")

  After this fix:
  That flag line is no longer visible in nonadmin command help.

  Verify nonadmin commands still work correctly:
  # Switch to a test namespace
  oc project test-namespace

  # Create a backup - uses current context namespace
  oc oadp nonadmin backup create test-backup --storage-location <your-nabsl>

  # Verify backup created in current namespace
  oc get nab test-backup -n test-namespace


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The --namespace flag is hidden from help for non-admin subcommands to reduce confusion.
  * Passing -n/--namespace to non-admin subcommands now returns a clear runtime error instead of being accepted silently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->