### PR TITLE
go.mod and go.sum to algin with docs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/migtools/oadp-cli
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/fatih/color v1.18.0
@@ -10,6 +10,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/vmware-tanzu/velero v1.16.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/term v0.42.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.33.11
 	k8s.io/apimachinery v0.33.11
@@ -75,7 +76,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oklog/run v1.0.0 // indirect
-	github.com/openshift/oadp-operator v1.0.2-0.20260528002306-f9a4a0870574 // indirect
+	github.com/openshift/oadp-operator v1.0.2-0.20260527004437-f1543b44c69c // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.4 // indirect
@@ -91,7 +92,6 @@ require (
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
-	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
@@ -111,8 +111,5 @@ require (
 	sigs.k8s.io/yaml v1.5.0 // indirect
 )
 
-// oadp-1.5: align openshift/velero fork with oadp-operator oadp-1.5
-replace github.com/vmware-tanzu/velero => github.com/openshift/velero v0.10.2-0.20251007230644-fbab83cfc995
-
-// oadp-non-admin oadp-1.5 pins this operator pseudo-version (avoids newer module zip issues)
-replace github.com/openshift/oadp-operator => github.com/openshift/oadp-operator v1.0.2-0.20250813014433-d5a424bd6488
+// oadp-1.5 latest velero commit on openshift
+replace github.com/vmware-tanzu/velero => github.com/openshift/velero v0.10.2-0.20260526143617-87a03c3d2c32

--- a/go.sum
+++ b/go.sum
@@ -440,10 +440,10 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.35.1 h1:Cwbd75ZBPxFSuZ6T+rN/WCb/gOc6YgFBXLlZLhC7Ds4=
 github.com/onsi/gomega v1.35.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
-github.com/openshift/oadp-operator v1.0.2-0.20250813014433-d5a424bd6488 h1:rR8p67df/Lcxrf6Mbhu4P42yVoOSvDYgZ81mpshDgHk=
-github.com/openshift/oadp-operator v1.0.2-0.20250813014433-d5a424bd6488/go.mod h1:Rysi54HrLBCSLV+Euuk93O+01dzSYY9YngH72ie7SRM=
-github.com/openshift/velero v0.10.2-0.20251007230644-fbab83cfc995 h1:E7LYe6kfHOgV/wVgXZeAFQpmDaq1YHCt1aEjlsPwgi8=
-github.com/openshift/velero v0.10.2-0.20251007230644-fbab83cfc995/go.mod h1:KexQjIRtgMGriCqpAIhY7YBNb2Mm7tfmXh6YWLb/dao=
+github.com/openshift/oadp-operator v1.0.2-0.20260527004437-f1543b44c69c h1:rmYGpH7xstFMZ/NG32rhIpirDMkQdPFi8F3LhcPoLII=
+github.com/openshift/oadp-operator v1.0.2-0.20260527004437-f1543b44c69c/go.mod h1:2u/F1epu6WvR+pvi4+cEhckE/QEHgLyOczC39fekGYA=
+github.com/openshift/velero v0.10.2-0.20260526143617-87a03c3d2c32 h1:1Iu7b6A/m74vmBiDHFO7sZ6ycXEfBpkE9eFODny99GA=
+github.com/openshift/velero v0.10.2-0.20260526143617-87a03c3d2c32/go.mod h1:KEpTfFgye9RJEXdq5BpYS2e07GEQiI/8IBKpnQp1X54=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=


### PR DESCRIPTION
## Why the changes were made

Changed go.mod and go.sum to match the design document. Bump openshift/velero replace to latest oadp-1.5 tip (87a03c3d2c32). Removed openshift/oadp-operator replace.

